### PR TITLE
Code cleanup

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -25,10 +25,12 @@ CheckOptions:
   - key: readability-identifier-naming.MacroDefinitionIgnoredRegexp
     value: '^DEBUG$'
   - key: readability-identifier-length.IgnoredParameterNames
-    value: '^[abijkpqr]$'
+    value: '^(ip|ts|[abijkpqr])$'
   - key: readability-identifier-length.IgnoredVariableNames
-    value: '^[A-Zijkpqr]$'
+    value: '^(ip|ts|[A-Zijkpqr])$'
   - key: readability-identifier-naming.LocalVariableIgnoredRegexp
-    value: '^[A-Zijkpqr]$'
+    value: '^(ip|ts|[A-Zijkpqr])$'
   - key: readability-magic-numbers.IgnoredIntegerValues
-    value: '1;2;3;4;5'
+    value: '1;2;3;4;5;8;10;16;24;32;255'
+  - key: misc-include-header.MissingIncludes
+    value: false

--- a/.github/workflows/check-all.yml
+++ b/.github/workflows/check-all.yml
@@ -15,6 +15,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Install build packages
+        run: |
+          sudo apt update
+          sudo apt install bear
+
+      - name: Generate compile_commands.json
+        run: |
+          bear -- make all
+
       - name: Check all
         uses: tsnlab/check@main
         with:

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ SRC=src
 OBJ=obj
 
 
+.PHONY: all lint createns deletens runclient runserver runpublisher runsubscriber dump1 dump2 clean
+
 all: libtickle.a client server
 
 OBJS = $(patsubst %,$(OBJ)/%,tickle.o hal.o)
@@ -28,8 +30,6 @@ publisher:  examples/uint64/UInt64.c examples/uint64/publisher.c libtickle.a
 
 subscriber: examples/uint64/UInt64.c examples/uint64/subscriber.c libtickle.a
 	$(CC) -o $@ examples/uint64/UInt64.c examples/uint64/subscriber.c -L. -ltickle $(CFLAGS)
-
-.PHONY: lint createns deletens runclient runserver runpublisher runsubscriber dump1 dump2 clean
 
 lint:
 	find . -name '*.[ch]' -exec clang-format --dry-run --Werror {} \;

--- a/examples/set_bool/SetBool.c
+++ b/examples/set_bool/SetBool.c
@@ -2,7 +2,7 @@
 
 #include "SetBool.h"
 
-#include <hal.h>
+#include <tickle/hal.h>
 
 struct tt_Service SetBoolService = {
     .name = "SetBoolService",

--- a/examples/set_bool/SetBool.h
+++ b/examples/set_bool/SetBool.h
@@ -1,7 +1,7 @@
 // Generated code
 #pragma oncde
 
-#include <tickle.h>
+#include <tickle/tickle.h>
 
 struct SetBoolRequest {
     bool data;

--- a/include/tickle/config.h
+++ b/include/tickle/config.h
@@ -5,7 +5,7 @@
 #define tt_MICROSECOND 1000ULL
 
 #define tt_NODE_CYCLE tt_MILLISECOND                   // nanosecond
-#define tt_NODE_UPDATE_INTERVAL 10 * tt_SECOND         // nanoseond  TODO: Temporary value for debugging
+#define tt_NODE_UPDATE_INTERVAL (10 * tt_SECOND)       // nanoseond  TODO: Temporary value for debugging
 #define tt_NODE_TX_INTERVAL tt_MILLISECOND             // nanoseond
 #define tt_RELIABLE_DEADLINE 0                         // nanosecond, 0 is auto
 #define tt_RELIABLE_RETRY 3                            // count

--- a/include/tickle/hal.h
+++ b/include/tickle/hal.h
@@ -15,6 +15,15 @@
 #define _tt_memmove(dest, src, n) memmove((dest), (src), (n))
 #define _tt_free(ptr) free((ptr))
 
+enum tickle_error {
+    tt_ERROR_NONE = 0,
+    tt_CANNOT_CREATE_SOCK = -3,
+    tt_CANNOT_SET_REUSEADDR = -4,
+    tt_CANNOT_SET_BROADCAST = -5,
+    tt_CANNOT_SET_TIMEOUT = -6,
+    tt_CANNOT_BIND_SOCKET = -7,
+};
+
 struct tt_Node;
 int32_t tt_get_node_id();
 int32_t tt_bind(struct tt_Node* node);

--- a/include/tickle/tickle.h
+++ b/include/tickle/tickle.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <config.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <tickle/config.h>
 
 #define tt_KIND_NONE 0x00
 #define tt_KIND_TOPIC 0x01
@@ -34,8 +34,8 @@ struct tt_Node {
     struct tt_UpdateHeader* updates[tt_MAX_ENDPOINT_COUNT];
 
     uint8_t tx_buffer[tt_MAX_BUFFER_LENGTH * 2];
-    int32_t tx_tail;
-    int32_t tx_size;
+    uint32_t tx_tail;
+    uint32_t tx_size;
 
     struct tt_TCB scheduler[tt_MAX_SCHEDULER_LENGTH];
     int32_t scheduler_tail;
@@ -93,13 +93,13 @@ struct tt_Request {};
 struct tt_Response {};
 
 typedef int32_t (*tt_REQUEST_ENCODE_SIZE)(struct tt_Request* request);
-typedef int32_t (*tt_REQUEST_ENCODE)(struct tt_Request* request, uint8_t* payload, const int32_t len);
-typedef int32_t (*tt_REQUEST_DECODE)(struct tt_Request* request, const uint8_t* payload, const int32_t len,
+typedef int32_t (*tt_REQUEST_ENCODE)(struct tt_Request* request, uint8_t* payload, const uint32_t len);
+typedef int32_t (*tt_REQUEST_DECODE)(struct tt_Request* request, const uint8_t* payload, const uint32_t len,
                                      bool is_native_endian);
 typedef void (*tt_REQUEST_FREE)(struct tt_Request* request);
 typedef int32_t (*tt_RESPONSE_ENCODE_SIZE)(struct tt_Response* response);
-typedef int32_t (*tt_RESPONSE_ENCODE)(struct tt_Response* response, uint8_t* payload, const int32_t len);
-typedef int32_t (*tt_RESPONSE_DECODE)(struct tt_Response* response, const uint8_t* payload, const int32_t len,
+typedef int32_t (*tt_RESPONSE_ENCODE)(struct tt_Response* response, uint8_t* payload, const uint32_t len);
+typedef int32_t (*tt_RESPONSE_DECODE)(struct tt_Response* response, const uint8_t* payload, const uint32_t len,
                                       bool is_native_endian);
 typedef void (*tt_RESPONSE_FREE)(struct tt_Response* response);
 
@@ -149,8 +149,8 @@ struct tt_Subscriber { // extends Endpoint
 };
 
 typedef int32_t (*tt_DATA_ENCODE_SIZE)(struct tt_Data* data);
-typedef int32_t (*tt_DATA_ENCODE)(struct tt_Data* data, uint8_t* payload, const int32_t len);
-typedef int32_t (*tt_DATA_DECODE)(struct tt_Data* data, const uint8_t* payload, const int32_t len,
+typedef int32_t (*tt_DATA_ENCODE)(struct tt_Data* data, uint8_t* payload, const uint32_t len);
+typedef int32_t (*tt_DATA_DECODE)(struct tt_Data* data, const uint8_t* payload, const uint32_t len,
                                   bool is_native_endian);
 typedef void (*tt_DATA_FREE)(struct tt_Data* data);
 

--- a/src/consts.h
+++ b/src/consts.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#define BITS_IN_1BYTE 8
+#define BITS_IN_2BYTES 16
+#define BITS_IN_3BYTES 24
+#define BITS_IN_4BYTES 32
+
+#define MASK_8BIT 0xff
+
+#define TIMEOUT_IN_MICROSECONDS 10

--- a/src/hal.c
+++ b/src/hal.c
@@ -1,14 +1,23 @@
+#include <bits/time.h>
 #include <ifaddrs.h>
+#include <stdint.h>
 #include <stdio.h>
-#include <tickle.h>
 #include <time.h>
 #include <unistd.h>
 
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
-#include <sys/time.h>
-#include <sys/types.h>
+
+#include <tickle/config.h>
+#include <tickle/hal.h>
+#include <tickle/tickle.h>
+
+#include "consts.h"
+
+#define SEC_NS 1000000000ULL
+
+#define UNUSED(x) (void)(x)
 
 struct _tt_Config _tt_CONFIG = {
     .addr = _tt_NODE_ADDRESS,
@@ -20,7 +29,7 @@ uint64_t tt_get_ns() {
     struct timespec ts;
     clock_gettime(CLOCK_REALTIME, &ts);
 
-    return (uint64_t)ts.tv_sec * 1000000000ULL + ts.tv_nsec;
+    return ((uint64_t)ts.tv_sec * SEC_NS) + ts.tv_nsec;
 }
 
 int32_t tt_get_node_id() {
@@ -44,7 +53,7 @@ int32_t tt_get_node_id() {
             if (node_id == 0) {
                 node_id = addr >> 24;
             } else if ((addr & netmask) == (broadcast_ip & netmask)) {
-                node_id = (addr & ~netmask) >> 24;
+                node_id = (addr & ~netmask) >> BITS_IN_3BYTES;
             }
         }
         ifaddr = ifaddr->ifa_next;
@@ -59,28 +68,28 @@ int32_t tt_bind(struct tt_Node* node) {
     node->sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
     if (node->sock < 0) {
         perror("Cannot create UDP socket");
-        return -3;
+        return tt_CANNOT_CREATE_SOCK;
     }
 
     int optval = 1;
     if (setsockopt(node->sock, SOL_SOCKET, SO_REUSEADDR, (const void*)&optval, sizeof(int)) < 0) {
         perror("Cannot set socket reuseaddr");
-        return -4;
+        return tt_CANNOT_SET_REUSEADDR;
     }
 
     optval = 1;
     if (setsockopt(node->sock, SOL_SOCKET, SO_BROADCAST, (const void*)&optval, sizeof(int)) < 0) {
         perror("Cannot set socket broadcast");
-        return -5;
+        return tt_CANNOT_SET_BROADCAST;
     }
 
     struct timeval timeout;
     timeout.tv_sec = 0;
-    timeout.tv_usec = 10;
+    timeout.tv_usec = TIMEOUT_IN_MICROSECONDS;
 
     if (setsockopt(node->sock, SOL_SOCKET, SO_RCVTIMEO, (const void*)&timeout, sizeof(struct timeval)) < 0) {
         perror("Cannot set socket receive timeout");
-        return -6;
+        return tt_CANNOT_SET_TIMEOUT;
     }
 
     struct sockaddr_in addr;
@@ -91,7 +100,7 @@ int32_t tt_bind(struct tt_Node* node) {
     if (bind(node->sock, (struct sockaddr*)&addr, sizeof(struct sockaddr_in)) < 0) {
         printf("Cannot binding socket: %s:%d\n", _tt_CONFIG.addr, _tt_CONFIG.port);
         perror("Cannot binding socket\n");
-        return -7;
+        return tt_CANNOT_BIND_SOCKET;
     }
 
     return 0;
@@ -107,14 +116,14 @@ int32_t tt_send(struct tt_Node* node, const void* buf, size_t len) {
     addr.sin_addr.s_addr = inet_addr(_tt_CONFIG.broadcast);
     addr.sin_port = htons(_tt_CONFIG.port);
 
-    return sendto(node->sock, buf, len, 0, (struct sockaddr*)&addr, sizeof(struct sockaddr_in));
+    return (int32_t)sendto(node->sock, buf, len, 0, (struct sockaddr*)&addr, sizeof(struct sockaddr_in));
 }
 
 int32_t tt_receive(struct tt_Node* node, void* buf, size_t len, uint32_t* ip, uint16_t* port) {
     struct sockaddr_in addr;
     int addr_len = sizeof(struct sockaddr_in);
 
-    int ret = recvfrom(node->sock, buf, len, 0, (struct sockaddr*)&addr, &addr_len);
+    int32_t ret = (int32_t)recvfrom(node->sock, buf, len, 0, (struct sockaddr*)&addr, &addr_len);
 
     *ip = ntohl(addr.sin_addr.s_addr);
     *port = ntohs(addr.sin_port);


### PR DESCRIPTION
This PR includes:

- [x] Change some clang-tidy configurations
- [x] Fix type warnings
- [x] Fix some possible bugs
- [x] Name some constants
- [x] Move api exposed header files into tickle directory, So that users will use <tickle/*.h>
  This avoids conflict filenames

Part of SW-1499