### PR TITLE
sw-2028: fix process callresponse latency calculation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,21 @@
 INCLUDE=include
 CC=gcc
 AR=ar
-CFLAGS=-I$(INCLUDE) -O0 -g
+CFLAGS=-I$(INCLUDE) -Isrc -O0 -g
+LDFLAGS=
+COVERAGE_FLAGS=--coverage
 
 SRC=src
 OBJ=obj
+# Unit tests are built as small, focused binaries under obj/tests.
+TEST=tests
+TEST_OBJ=$(OBJ)/tests
+TEST_SRCS=$(wildcard $(TEST)/test_*.c)
+TEST_NAMES=$(basename $(notdir $(TEST_SRCS)))
+TEST_BINS=$(addprefix $(TEST_OBJ)/,$(TEST_NAMES))
+COVERAGE_DIR=$(TEST)/coverage
+# Keep coverage output focused on each test translation unit and included source under test.
+COVERAGE_FILES=$(foreach test,$(TEST_NAMES),$(TEST_OBJ)/$(test)-$(test).gcno)
 
 # Platform detection
 UNAME_S := $(shell uname -s)
@@ -23,15 +34,49 @@ SRC_FILES = $(filter-out $(SRC)/hal_%.c, $(wildcard $(SRC)/*.c))
 SRC_FILES += $(HAL_SRC)
 OBJS = $(patsubst $(SRC)/%.c,$(OBJ)/%.o,$(SRC_FILES))
 
-.PHONY: all lint createns deletens runclient runserver runpublisher runsubscriber dump1 dump2 clean
+.PHONY: all library examples set_bool uint64 test run-tests coverage coverage-report lint createns deletens runclient runserver runpublisher runsubscriber dump1 dump2 clean
 
-all: libtickle.a client server
+all:
+	$(MAKE) test
+	$(MAKE) library
+	$(MAKE) examples
+
+library: libtickle.a
+
+examples: set_bool uint64
+
+set_bool: client server
+
+uint64: publisher subscriber
 
 $(OBJ)/%.o: $(SRC)/%.c
+	mkdir -p $(dir $@)
 	$(CC) -c -o $@ $< $(CFLAGS)
 
 libtickle.a: $(OBJS)
 	$(AR) crv $@ $^
+
+$(TEST_OBJ)/%: $(TEST)/%.c $(SRC)/tickle.c $(SRC)/encoding.c $(SRC)/log.c
+	mkdir -p $(dir $@)
+	$(CC) -o $@ $< $(SRC)/encoding.c $(SRC)/log.c $(CFLAGS) $(LDFLAGS)
+
+# Run tests with coverage instrumentation; reports are generated only if tests pass.
+test:
+	$(MAKE) clean
+	$(MAKE) CFLAGS="$(CFLAGS) $(COVERAGE_FLAGS)" LDFLAGS="$(LDFLAGS) $(COVERAGE_FLAGS)" run-tests
+	$(MAKE) coverage-report
+
+run-tests: $(TEST_BINS)
+	@for test_bin in $(TEST_BINS); do \
+		./$$test_bin || exit 1; \
+	done
+
+coverage: test
+
+coverage-report:
+	mkdir -p $(COVERAGE_DIR)
+	gcov $(COVERAGE_FILES)
+	mv *.gcov $(COVERAGE_DIR)/
 
 client:  examples/set_bool/SetBool.c examples/set_bool/client.c libtickle.a
 	$(CC) -o $@ examples/set_bool/SetBool.c examples/set_bool/client.c -L. -ltickle $(CFLAGS)
@@ -100,6 +145,8 @@ dump2:
 
 clean:
 	rm -rf $(OBJ)/*
+	rm -rf $(COVERAGE_DIR)
+	rm -f *.gcov
 	rm -f libtickle.a
 	rm -f client
 	rm -f server

--- a/README.md
+++ b/README.md
@@ -1,10 +1,59 @@
 # TickLE: Fastest ROS2 middleware optimized for 10Base-T1S
 
-## Compile
+## Build
 
 ```sh
-$ make
+$ make all      # Run unit tests, build the library, then build all examples
+$ make library  # Build libtickle.a only
+$ make examples # Build all examples without running unit tests
+$ make set_bool # Build SetBool client/server examples
+$ make uint64   # Build UInt64 publisher/subscriber examples
 ```
+
+## Unit Tests
+
+```sh
+$ make test
+```
+
+`make test` builds each unit test with coverage instrumentation, runs the tests, and writes coverage reports to `tests/coverage/` only when all tests pass.
+
+### Adding Unit Tests
+
+Add one focused test file per behavior using the `tests/test_*.c` naming pattern, for example `tests/test_callresponse.c`. `make test` discovers those files automatically and builds one binary per test file under `obj/tests/`.
+
+A typical test file should:
+
+1. Include `tests/test_common.h` for assertions. Define `TEST_COMMON_DEFINE_STORAGE` before including it in exactly one file per test binary.
+2. Include `tests/test_mock.h` when the test needs HAL/time mocks. Define `TEST_MOCK_DEFINE_STORAGE` before including it in exactly one file per test binary.
+3. Include the implementation file under test, such as `#include "../src/tickle.c"`, when static functions need to be exercised without changing production visibility.
+4. Add focused test functions for one behavior or regression.
+5. Call those test functions from `main()`, then return `test_result()`.
+
+Minimal structure:
+
+```c
+#define TEST_COMMON_DEFINE_STORAGE
+#include "test_common.h"
+
+#define TEST_MOCK_DEFINE_STORAGE
+#include "test_mock.h"
+
+#include "../src/tickle.c"
+
+static void test_some_behavior(void) {
+    test_mock_reset();
+    /* Arrange inputs, call the code under test, then assert results. */
+    EXPECT_TRUE(true);
+}
+
+int main(void) {
+    test_some_behavior();
+    return test_result();
+}
+```
+
+Run `make test` after adding the file. Coverage reports are written to `tests/coverage/`; review the matching `.gcov` file for the code under test.
 
 ## Run examples
 ```sh

--- a/examples/uint64/UInt64.c
+++ b/examples/uint64/UInt64.c
@@ -2,7 +2,7 @@
 
 #include "UInt64.h"
 
-#include <hal.h>
+#include <tickle/hal.h>
 
 struct tt_Topic UInt64Topic = {
     .name = "UInt64Topic",

--- a/examples/uint64/UInt64.h
+++ b/examples/uint64/UInt64.h
@@ -1,7 +1,7 @@
 // Generated code
 #pragma once
 
-#include <tickle.h>
+#include <tickle/tickle.h>
 
 struct UInt64Data {
     uint64_t data;

--- a/examples/uint64/UInt64.h
+++ b/examples/uint64/UInt64.h
@@ -1,5 +1,5 @@
 // Generated code
-#pragma oncde
+#pragma once
 
 #include <tickle.h>
 

--- a/src/tickle.c
+++ b/src/tickle.c
@@ -12,6 +12,10 @@
 
 #define UNUSED(x) (void)(x)
 
+static uint32_t calculate_latency(uint64_t start, uint64_t end) {
+    return end > start ? (uint32_t)(end - start) : 0;
+}
+
 static struct tt_SubmessageHeader* start_encode(struct tt_Node* node, uint8_t type, uint8_t receiver) {
     if (node->tx_tail + sizeof(struct tt_SubmessageHeader) >= node->tx_size) {
         TT_LOG_ERROR("Lack of tx buffer");
@@ -965,7 +969,7 @@ static bool process_callresponse(struct tt_Node* node, struct tt_Header* header,
 
     struct tt_Client* client = (struct tt_Client*)endpoint;
     struct tt_Service* service = client->service;
-    uint32_t latency = client->cache_time - tt_get_ns();
+    uint32_t latency = calculate_latency(client->cache_time, tt_get_ns());
 
     struct tt_Response* response = NULL;
     uint8_t response_buffer[service->response_size];

--- a/tests/test_callresponse.c
+++ b/tests/test_callresponse.c
@@ -1,0 +1,86 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <tickle/tickle.h>
+
+// This file owns the shared test assertion state for this test binary.
+#define TEST_COMMON_DEFINE_STORAGE
+#include "test_common.h"
+
+// This file owns the HAL/time mocks used by the included tickle.c implementation.
+#define TEST_MOCK_DEFINE_STORAGE
+#include "test_mock.h"
+
+static int callback_count = 0;
+static int8_t callback_return_code = 0;
+static struct tt_Response* callback_response = (struct tt_Response*)1;
+
+static void test_client_callback(struct tt_Client* client, int8_t return_code, struct tt_Response* response) {
+    (void)client;
+    callback_count++;
+    callback_return_code = return_code;
+    callback_response = response;
+}
+
+// Include the implementation to exercise static call-response code without widening production visibility.
+#include "../src/tickle.c"
+
+// Regression test for latency measured from request cache time to response receive time.
+static void test_callresponse_updates_latency_from_cache_time_to_now(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+
+    struct tt_Service service;
+    memset(&service, 0, sizeof(service));
+
+    struct tt_Client client;
+    memset(&client, 0, sizeof(client));
+    client.super.kind = tt_KIND_SERVICE_CLIENT;
+    client.super.id = 0x12345678;
+    client.service = &service;
+    client.callback = test_client_callback;
+    client.cache = malloc(1);
+    client.cache_time = 1000;
+    client.latency = 0;
+
+    node.id = 1;
+    node.endpoint_count = 1;
+    node.endpoints[0] = (struct tt_Endpoint*)&client;
+
+    struct tt_Header header;
+    memset(&header, 0, sizeof(header));
+    header.magic_value = NATIVE_MAGIC_VALUE;
+    header.version = tt_VERSION;
+    header.source = 2;
+
+    struct tt_CallResponseHeader response_header;
+    memset(&response_header, 0, sizeof(response_header));
+    response_header.id = client.super.id;
+    response_header.seq_no = 7;
+    response_header.return_code = 1;
+
+    test_mock_reset();
+    test_mock_now = 1250;
+    callback_count = 0;
+    callback_return_code = 0;
+    callback_response = (struct tt_Response*)1;
+
+    EXPECT_TRUE(process_callresponse(&node, &header, (uint8_t*)&response_header, 0, sizeof(response_header)));
+    EXPECT_EQ_U32(250, client.latency);
+    EXPECT_TRUE(client.cache == NULL);
+    EXPECT_EQ_U32(1, callback_count);
+    EXPECT_EQ_U32(1, callback_return_code);
+    EXPECT_TRUE(callback_response == NULL);
+}
+
+int main(void) {
+    test_callresponse_updates_latency_from_cache_time_to_now();
+
+    if (test_result() != 0) {
+        return 1;
+    }
+
+    printf("callresponse tests passed\n");
+    return 0;
+}

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -1,0 +1,43 @@
+#pragma once
+
+// Shared helpers for focused C unit-test binaries.
+// Keep this header small so tests can stay framework-free.
+
+#include <stdint.h>
+#include <stdio.h>
+
+// Define storage in exactly one test binary; other files can include this header as extern declarations.
+#ifdef TEST_COMMON_DEFINE_STORAGE
+int test_failures = 0;
+#else
+extern int test_failures;
+#endif
+
+// Minimal assertions keep test files dependency-free and easy to add incrementally.
+#define EXPECT_TRUE(expr) \
+    do { \
+        if (!(expr)) { \
+            fprintf(stderr, "%s:%d: expected true: %s\n", __FILE__, __LINE__, #expr); \
+            test_failures++; \
+        } \
+    } while (0)
+
+#define EXPECT_EQ_U32(expected, actual) \
+    do { \
+        uint32_t expected_value = (expected); \
+        uint32_t actual_value = (actual); \
+        if (expected_value != actual_value) { \
+            fprintf(stderr, "%s:%d: expected %u, got %u\n", __FILE__, __LINE__, expected_value, actual_value); \
+            test_failures++; \
+        } \
+    } while (0)
+
+// Return a process status that make can use directly.
+static inline int test_result(void) {
+    if (test_failures != 0) {
+        fprintf(stderr, "%d test assertions failed\n", test_failures);
+        return 1;
+    }
+
+    return 0;
+}

--- a/tests/test_mock.h
+++ b/tests/test_mock.h
@@ -1,0 +1,85 @@
+#pragma once
+
+// Shared HAL/time mocks for tests that include production .c files directly.
+// Tests can override the exported state variables after test_mock_reset().
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+
+#include <tickle/config.h>
+#include <tickle/tickle.h>
+
+// Define mock HAL symbols in one test binary so tickle.c can be included directly.
+#ifdef TEST_MOCK_DEFINE_STORAGE
+struct _tt_Config _tt_CONFIG = {
+    .addr = _tt_NODE_ADDRESS,
+    .port = _tt_NODE_PORT,
+    .broadcast = _tt_NODE_BROADCAST,
+};
+
+// Mock state defaults to a quiet node with no incoming packets.
+uint64_t test_mock_now = 0;
+int32_t test_mock_node_id = 1;
+int32_t test_mock_bind_return = 0;
+int32_t test_mock_receive_return = -1;
+bool test_mock_send_return_override = false;
+int32_t test_mock_send_return = 0;
+#else
+extern uint64_t test_mock_now;
+extern int32_t test_mock_node_id;
+extern int32_t test_mock_bind_return;
+extern int32_t test_mock_receive_return;
+extern bool test_mock_send_return_override;
+extern int32_t test_mock_send_return;
+#endif
+
+// Tests may override these globals after reset to drive specific timing or HAL outcomes.
+static inline void test_mock_reset(void) {
+    test_mock_now = 0;
+    test_mock_node_id = 1;
+    test_mock_bind_return = 0;
+    test_mock_receive_return = -1;
+    test_mock_send_return_override = false;
+    test_mock_send_return = 0;
+}
+
+#ifdef TEST_MOCK_DEFINE_STORAGE
+// These functions replace the platform HAL symbols when building a test binary.
+uint64_t tt_get_ns() {
+    return test_mock_now;
+}
+
+int32_t tt_get_node_id() {
+    return test_mock_node_id;
+}
+
+int32_t tt_bind(struct tt_Node* node) {
+    (void)node;
+    return test_mock_bind_return;
+}
+
+void tt_close(struct tt_Node* node) {
+    (void)node;
+}
+
+int32_t tt_send(struct tt_Node* node, const void* buf, size_t len) {
+    (void)node;
+    (void)buf;
+
+    if (test_mock_send_return_override) {
+        return test_mock_send_return;
+    }
+
+    return (int32_t)len;
+}
+
+int32_t tt_receive(struct tt_Node* node, void* buf, size_t len, uint32_t* ip, uint16_t* port) {
+    (void)node;
+    (void)buf;
+    (void)len;
+    (void)ip;
+    (void)port;
+    return test_mock_receive_return;
+}
+#endif


### PR DESCRIPTION
1. Purpose 

- Fix an incorrect latency calculation in process_callresponse(), where the elapsed time was computed in reverse order and could underflow.
- Add Unit tests: test and coverage

2. Overview

- Correct call response latency calculation to use response receive time minus request cache time.
- Add focused unit test infrastructure with automatic test discovery.
- Add HAL/time mocks and shared assertion helpers for unit tests.
- Generate coverage reports under tests/coverage/ when make test succeeds.
- Fix UInt64 generated header pragma typo.
- Update Readme

3. Test

make test

4. Issue
- Linear: [SW-2028](https://linear.app/tsnlab/issue/SW-2028/process-callresponse-%EC%97%90%EC%84%9C-latency-%EA%B3%84%EC%82%B0-%EC%98%A4%EB%A5%98)