### PR TITLE
SW-2019, SW-2022, SW-2053: Fix node creation and endpoint registration safety

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ COVERAGE_FILES=$(foreach test,$(TEST_NAMES),$(TEST_OBJ)/$(test)-$(test).gcno)
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
     PLATFORM := linux
+    CFLAGS += -pthread
+    LDFLAGS += -pthread
 else
     PLATFORM := generic
 endif
@@ -79,16 +81,16 @@ coverage-report:
 	mv *.gcov $(COVERAGE_DIR)/
 
 client:  examples/set_bool/SetBool.c examples/set_bool/client.c libtickle.a
-	$(CC) -o $@ examples/set_bool/SetBool.c examples/set_bool/client.c -L. -ltickle $(CFLAGS)
+	$(CC) -o $@ examples/set_bool/SetBool.c examples/set_bool/client.c -L. -ltickle $(CFLAGS) $(LDFLAGS)
 
 server: examples/set_bool/SetBool.c examples/set_bool/server.c libtickle.a
-	$(CC) -o $@ examples/set_bool/SetBool.c examples/set_bool/server.c -L. -ltickle $(CFLAGS)
+	$(CC) -o $@ examples/set_bool/SetBool.c examples/set_bool/server.c -L. -ltickle $(CFLAGS) $(LDFLAGS)
 
 publisher:  examples/uint64/UInt64.c examples/uint64/publisher.c libtickle.a
-	$(CC) -o $@ examples/uint64/UInt64.c examples/uint64/publisher.c -L. -ltickle $(CFLAGS)
+	$(CC) -o $@ examples/uint64/UInt64.c examples/uint64/publisher.c -L. -ltickle $(CFLAGS) $(LDFLAGS)
 
 subscriber: examples/uint64/UInt64.c examples/uint64/subscriber.c libtickle.a
-	$(CC) -o $@ examples/uint64/UInt64.c examples/uint64/subscriber.c -L. -ltickle $(CFLAGS)
+	$(CC) -o $@ examples/uint64/UInt64.c examples/uint64/subscriber.c -L. -ltickle $(CFLAGS) $(LDFLAGS)
 
 lint:
 	find . -name '*.[ch]' -exec clang-format --dry-run --Werror {} \;

--- a/include/tickle/config.h
+++ b/include/tickle/config.h
@@ -13,10 +13,16 @@
 #define tt_CALL_RETRY_COUNT 3                          // count
 #define tt_SERVER_CACHE_TIMEOUT (100 * tt_MILLISECOND) // (Client server latency) * (CALL_RETRY_COUNT + 1)
 
-#define tt_MAX_ENDPOINT_COUNT 256    // Maximum number of endpoints (data or services)
-#define tt_MAX_NAME_LENGTH 32        // Maximum length of endpoint name
-#define tt_MAX_STRING_LENGTH 65535   // Maximum length of string
-#define tt_MAX_BUFFER_LENGTH 1480    // TX buffer size
+#define tt_MAX_ENDPOINT_COUNT 256  // Maximum number of endpoints (data or services)
+#define tt_MAX_NAME_LENGTH 32      // Maximum length of endpoint name
+#define tt_MAX_STRING_LENGTH 65535 // Maximum length of string
+#define tt_MAX_BUFFER_LENGTH 1480  // TX buffer size
+
+// Node ID values are the last byte of the IPv4 address on the local network.
+// Valid node IDs are 1..254, because 0 is reserved for invalid/unassigned and
+// 255 is reserved for the broadcast address.
+#define tt_NODE_ID_INVALID 0x00
+#define tt_NODE_ID_BROADCAST 0xff
 #define tt_MAX_SCHEDULER_LENGTH 128  // Scheduling queue
 #define tt_MAX_SERVER_CACHE_COUNT 64 // >= # of client
 

--- a/include/tickle/hal.h
+++ b/include/tickle/hal.h
@@ -6,6 +6,10 @@
 #include <stdlib.h>
 #include <string.h> // NOLINT(misc-include-cleaner)
 
+#if defined(__linux__)
+#include <pthread.h>
+#endif
+
 // Platform detection macros
 #if defined(__linux__)
 #define TT_PLATFORM_LINUX
@@ -33,16 +37,25 @@
 #define REVERSE_MAGIC_VALUE (((uint16_t)'K' << 8) | 'T')
 
 enum tickle_error {
-    tt_ERROR_NONE = 0,
-    tt_CANNOT_CREATE_SOCK = -3,
-    tt_CANNOT_SET_REUSEADDR = -4,
-    tt_CANNOT_SET_BROADCAST = -5,
-    tt_CANNOT_SET_TIMEOUT = -6,
-    tt_CANNOT_BIND_SOCKET = -7,
+    tt_ERROR_NONE = 0,            // No error
+    tt_CANNOT_CREATE_SOCK = -3,   // Failed to create the underlying socket
+    tt_CANNOT_SET_REUSEADDR = -4, // Failed to enable socket address reuse
+    tt_CANNOT_SET_BROADCAST = -5, // Failed to enable broadcast on the socket
+    tt_CANNOT_SET_TIMEOUT = -6,   // Failed to configure socket timeout
+    tt_CANNOT_BIND_SOCKET = -7,   // Failed to bind socket to local address/port
+    tt_TOO_MANY_ENDPOINTS = -8,   // Node already has maximum endpoints registered
+    tt_DUPLICATE_ENDPOINT = -9,   // Endpoint kind+id already exists in node registry
 };
 
 struct tt_Node;
 struct tt_Header;
+
+#ifdef TT_PLATFORM_LINUX
+typedef pthread_mutex_t tt_lock_t;
+#else
+typedef int tt_lock_t;
+#endif
+typedef uintptr_t tt_lock_state_t;
 
 // Platform-specific HAL structure inclusion
 #ifdef TT_PLATFORM_LINUX
@@ -52,6 +65,10 @@ struct tt_Header;
 #endif
 
 // Network functions
+void tt_lock_init(tt_lock_t* lock);
+void tt_lock_deinit(tt_lock_t* lock);
+tt_lock_state_t tt_lock(tt_lock_t* lock);
+void tt_unlock(tt_lock_t* lock, tt_lock_state_t state);
 int32_t tt_get_node_id();
 int32_t tt_bind(struct tt_Node* node);
 void tt_close(struct tt_Node* node);

--- a/include/tickle/hal.h
+++ b/include/tickle/hal.h
@@ -4,11 +4,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <string.h> // NOLINT(misc-include-cleaner)
-
 #if defined(__linux__)
-#include <pthread.h>
+#include <pthread.h> // NOLINT(misc-include-cleaner)
 #endif
+#include <string.h> // NOLINT(misc-include-cleaner)
 
 // Platform detection macros
 #if defined(__linux__)
@@ -51,11 +50,10 @@ struct tt_Node;
 struct tt_Header;
 
 #ifdef TT_PLATFORM_LINUX
-typedef pthread_mutex_t tt_lock_t;
+typedef pthread_mutex_t tt_lock_t; // NOLINT(misc-include-cleaner)
 #else
 typedef int tt_lock_t;
 #endif
-typedef uintptr_t tt_lock_state_t;
 
 // Platform-specific HAL structure inclusion
 #ifdef TT_PLATFORM_LINUX
@@ -63,6 +61,8 @@ typedef uintptr_t tt_lock_state_t;
 #elif defined(TT_PLATFORM_GENERIC)
 #include <tickle/hal_generic.h> // NOLINT(misc-include-cleaner)
 #endif
+
+typedef uintptr_t tt_lock_state_t;
 
 // Network functions
 void tt_lock_init(tt_lock_t* lock);

--- a/include/tickle/tickle.h
+++ b/include/tickle/tickle.h
@@ -42,6 +42,8 @@ struct tt_Node {
     struct tt_TCB scheduler[tt_MAX_SCHEDULER_LENGTH];
     int32_t scheduler_tail;
 
+    tt_lock_t endpoint_lock;
+
     // tt_hal is defined indirectly via <tickle/hal.h>, which includes the
     // platform-specific HAL header (<tickle/hal_linux.h> or <tickle/hal_generic.h>).
     struct tt_hal hal; // NOLINT(misc-include-cleaner)
@@ -49,7 +51,8 @@ struct tt_Node {
 
 struct tt_Endpoint {
     uint8_t kind;
-    uint32_t id; // hash(type + name)
+    uint32_t id;       // hash(endpoint kind + endpoint name)
+    uint32_t topic_id; // shared topic routing id for publisher/subscriber fan-out
     const char* name;
 };
 
@@ -60,8 +63,8 @@ struct tt_SubmessageHeader;
 
 typedef void (*tt_CLIENT_CALLBACK)(struct tt_Client* client, int8_t return_code, struct tt_Response* response);
 
-struct tt_Client { // extends Endpoint
-    struct tt_Endpoint super;
+struct tt_Client { // embeds endpoint metadata
+    struct tt_Endpoint endpoint;
     struct tt_Node* node;
     struct tt_Service* service;
     tt_CLIENT_CALLBACK callback;
@@ -81,8 +84,8 @@ struct tt_Request;
 typedef int8_t (*tt_SERVER_CALLBACK)(struct tt_Server* server, struct tt_Request* request,
                                      struct tt_Response* response);
 
-struct tt_Server { // extends Endpoint
-    struct tt_Endpoint super;
+struct tt_Server { // embeds endpoint metadata
+    struct tt_Endpoint endpoint;
     struct tt_Node* node;
     struct tt_Service* service;
     tt_SERVER_CALLBACK callback;
@@ -127,8 +130,8 @@ struct tt_Topic;
 
 struct tt_Data {};
 
-struct tt_Publisher { // extends Endpoint
-    struct tt_Endpoint super;
+struct tt_Publisher { // embeds endpoint metadata
+    struct tt_Endpoint endpoint;
     struct tt_Node* node;
     struct tt_Topic* topic;
 
@@ -140,8 +143,8 @@ struct tt_Subscriber;
 typedef void (*tt_SUBSCRIBER_CALLBACK)(struct tt_Subscriber* subscriber, uint64_t time, uint16_t seq_no,
                                        struct tt_Data* data);
 
-struct tt_Subscriber { // extends Endpoint
-    struct tt_Endpoint super;
+struct tt_Subscriber { // embeds endpoint metadata
+    struct tt_Endpoint endpoint;
     struct tt_Node* node;
     struct tt_Topic* topic;
     tt_SUBSCRIBER_CALLBACK callback;
@@ -181,13 +184,13 @@ uint64_t tt_get_ns();
  */
 int32_t tt_Node_create(struct tt_Node* node);
 int32_t tt_Node_create_client(struct tt_Node* node, struct tt_Client* client, struct tt_Service* service,
-                              const char* name, tt_CLIENT_CALLBACK callback);
+                              const char* endpoint_name, tt_CLIENT_CALLBACK callback);
 int32_t tt_Node_create_server(struct tt_Node* node, struct tt_Server* server, struct tt_Service* service,
-                              const char* name, tt_SERVER_CALLBACK callback);
+                              const char* endpoint_name, tt_SERVER_CALLBACK callback);
 int32_t tt_Node_create_publisher(struct tt_Node* node, struct tt_Publisher* pub, struct tt_Topic* topic,
-                                 const char* name);
+                                 const char* endpoint_name);
 int32_t tt_Node_create_subscriber(struct tt_Node* node, struct tt_Subscriber* sub, struct tt_Topic* topic,
-                                  const char* name, tt_SUBSCRIBER_CALLBACK callback);
+                                  const char* endpoint_name, tt_SUBSCRIBER_CALLBACK callback);
 bool tt_Node_schedule(struct tt_Node* node, uint64_t time,
                       void (*function)(struct tt_Node* node, uint64_t time, void* param), void* param);
 
@@ -241,7 +244,7 @@ struct tt_UpdateHeader {
 } __attribute__((packed));
 
 struct tt_UpdateEntity {
-    uint32_t id; // endpoint id: hash(type + name)
+    uint32_t endpoint_id; // hash(endpoint kind + endpoint name)
     uint8_t kind;
     /* Dynamically allocated
     uint16_t type_len;
@@ -252,7 +255,7 @@ struct tt_UpdateEntity {
 } __attribute__((packed));
 
 struct tt_DataHeader {
-    uint32_t id; // endpoint id
+    uint32_t topic_id; // topic routing identity
     uint32_t seq_no;
     uint64_t timestamp;
     // type + name
@@ -266,17 +269,17 @@ struct tt_AckNackHeader {
 } __attribute__((packed));
 
 struct tt_CallRequestHeader {
-    uint32_t id;     // endpoint id
-    uint16_t seq_no; // sequence number
-    uint8_t retry;   // retry count from client side
+    uint32_t endpoint_id; // endpoint id for service server lookup
+    uint16_t seq_no;      // sequence number
+    uint8_t retry;        // retry count from client side
     // CDR
 } __attribute__((packed));
 
 struct tt_CallResponseHeader {
-    uint32_t id;        // endpoint id
-    uint16_t seq_no;    // sequence number
-    uint8_t retry;      // retry count from server side
-    int8_t return_code; // return code
+    uint32_t endpoint_id; // endpoint id for client routing
+    uint16_t seq_no;      // sequence number
+    uint8_t retry;        // retry count from server side
+    int8_t return_code;   // return code
     // type + name
     // CDR
 } __attribute__((packed));

--- a/src/hal_linux.c
+++ b/src/hal_linux.c
@@ -36,6 +36,34 @@ uint64_t tt_get_ns() {
     return ((uint64_t)ts.tv_sec * SEC_NS) + ts.tv_nsec;
 }
 
+void tt_lock_init(tt_lock_t* lock) {
+    if (pthread_mutex_init(lock, NULL) != 0) {
+        perror("Cannot initialize node lock");
+    }
+}
+
+void tt_lock_deinit(tt_lock_t* lock) {
+    if (pthread_mutex_destroy(lock) != 0) {
+        perror("Cannot destroy node lock");
+    }
+}
+
+tt_lock_state_t tt_lock(tt_lock_t* lock) {
+    if (pthread_mutex_lock(lock) != 0) {
+        perror("Cannot lock node mutex");
+    }
+
+    return 0;
+}
+
+void tt_unlock(tt_lock_t* lock, tt_lock_state_t state) {
+    UNUSED(state);
+
+    if (pthread_mutex_unlock(lock) != 0) {
+        perror("Cannot unlock node mutex");
+    }
+}
+
 int32_t tt_get_node_id() {
     // Get unique node ID in the network using IP address x.x.x.id
     uint32_t broadcast_ip = inet_addr(_tt_CONFIG.broadcast);

--- a/src/tickle.c
+++ b/src/tickle.c
@@ -194,7 +194,7 @@ static bool remove_endpoint_from_node(struct tt_Node* node, struct tt_Endpoint* 
         if (node->endpoints[i] == endpoint) {
             node->endpoint_count--;
             if (i < node->endpoint_count) {
-                _tt_memmove(&node->endpoints[i], &node->endpoints[i + 1],
+                _tt_memmove((void*)&node->endpoints[i], (const void*)&node->endpoints[i + 1],
                             sizeof(struct tt_Endpoint*) * (node->endpoint_count - i));
             }
             node->endpoints[node->endpoint_count] = NULL;

--- a/src/tickle.c
+++ b/src/tickle.c
@@ -12,6 +12,14 @@
 
 #define UNUSED(x) (void)(x)
 
+static tt_lock_state_t lock_endpoints(struct tt_Node* node) {
+    return tt_lock(&node->endpoint_lock);
+}
+
+static void unlock_endpoints(struct tt_Node* node, tt_lock_state_t state) {
+    tt_unlock(&node->endpoint_lock, state);
+}
+
 static uint32_t calculate_latency(uint64_t start, uint64_t end) {
     return end > start ? (uint32_t)(end - start) : 0;
 }
@@ -136,15 +144,67 @@ static bool decode_string(struct tt_Node* node, uint8_t* buffer, uint32_t* head,
     return true;
 }
 
-static struct tt_Endpoint* find_endpoint(struct tt_Node* node, uint8_t kind, uint32_t id) {
-    for (int i = 0; i < node->endpoint_count; i++) {
+static struct tt_Endpoint* find_endpoint(struct tt_Node* node, uint8_t kind, uint32_t endpoint_id) {
+    tt_lock_state_t state = lock_endpoints(node);
+
+    for (uint32_t i = 0; i < node->endpoint_count; i++) {
         struct tt_Endpoint* endpoint = node->endpoints[i];
-        if (endpoint->kind == kind && endpoint->id == id) {
+        if (endpoint == NULL) {
+            continue;
+        }
+        if ((endpoint->kind == kind) && (endpoint->id == endpoint_id)) {
+            unlock_endpoints(node, state);
             return endpoint;
         }
     }
 
+    unlock_endpoints(node, state);
     return NULL;
+}
+
+static int32_t add_endpoint_to_node(struct tt_Node* node, struct tt_Endpoint* endpoint) {
+    tt_lock_state_t state = lock_endpoints(node);
+
+    if (node->endpoint_count >= tt_MAX_ENDPOINT_COUNT) {
+        uint32_t endpoint_count = node->endpoint_count;
+        unlock_endpoints(node, state);
+        TT_LOG_ERROR("Too many endpoints: %u", endpoint_count);
+        return tt_TOO_MANY_ENDPOINTS;
+    }
+
+    for (uint32_t i = 0; i < node->endpoint_count; i++) {
+        struct tt_Endpoint* current = node->endpoints[i];
+        if ((current != NULL) && (current->kind == endpoint->kind) && (current->id == endpoint->id)) {
+            unlock_endpoints(node, state);
+            TT_LOG_ERROR("Duplicate endpoint kind=%u id=%u", endpoint->kind, endpoint->id);
+            return tt_DUPLICATE_ENDPOINT;
+        }
+    }
+
+    node->endpoints[node->endpoint_count++] = endpoint;
+    unlock_endpoints(node, state);
+
+    return tt_ERROR_NONE;
+}
+
+static bool remove_endpoint_from_node(struct tt_Node* node, struct tt_Endpoint* endpoint) {
+    tt_lock_state_t state = lock_endpoints(node);
+
+    for (uint32_t i = 0; i < node->endpoint_count; i++) {
+        if (node->endpoints[i] == endpoint) {
+            node->endpoint_count--;
+            if (i < node->endpoint_count) {
+                _tt_memmove(&node->endpoints[i], &node->endpoints[i + 1],
+                            sizeof(struct tt_Endpoint*) * (node->endpoint_count - i));
+            }
+            node->endpoints[node->endpoint_count] = NULL;
+            unlock_endpoints(node, state);
+            return true;
+        }
+    }
+
+    unlock_endpoints(node, state);
+    return false;
 }
 
 bool tt_Node_schedule(struct tt_Node* node, uint64_t time,
@@ -189,7 +249,7 @@ static void node_update(struct tt_Node* node, uint64_t time, void* param);
 static void node_flush(struct tt_Node* node, uint64_t time, void* param);
 
 int32_t tt_Node_create(struct tt_Node* node) {
-    node->id = 0;
+    node->id = tt_NODE_ID_INVALID;
     node->endpoint_count = 0;
 
     for (int i = 0; i < tt_MAX_ENDPOINT_COUNT; i++) {
@@ -209,15 +269,19 @@ int32_t tt_Node_create(struct tt_Node* node) {
     memset(node->scheduler, 0, sizeof(struct tt_TCB) * tt_MAX_SCHEDULER_LENGTH);
     node->scheduler_tail = 0;
 
+    tt_lock_init(&node->endpoint_lock);
+
     node->id = tt_get_node_id();
 
-    if (node->id == 0) {
-        TT_LOG_ERROR("Cannot get node id from IP address");
+    if (node->id == tt_NODE_ID_INVALID || node->id == tt_NODE_ID_BROADCAST) {
+        TT_LOG_ERROR("Invalid node id: %u", node->id);
+        tt_lock_deinit(&node->endpoint_lock);
         return -2;
     }
 
     if (tt_bind(node) != 0) {
         TT_LOG_ERROR("Cannot bind");
+        tt_lock_deinit(&node->endpoint_lock);
         return -3;
     }
 
@@ -230,11 +294,15 @@ int32_t tt_Node_create(struct tt_Node* node) {
 
     if (!tt_Node_schedule(node, basetime, node_update, NULL)) {
         TT_LOG_ERROR("Cannot schedule node_update");
+        tt_close(node);
+        tt_lock_deinit(&node->endpoint_lock);
         return -1;
     }
 
     if (!tt_Node_schedule(node, basetime + tt_NODE_TX_INTERVAL, node_flush, NULL)) {
         TT_LOG_ERROR("Cannot schedule node_flush");
+        tt_close(node);
+        tt_lock_deinit(&node->endpoint_lock);
         return -1;
     }
 
@@ -242,12 +310,12 @@ int32_t tt_Node_create(struct tt_Node* node) {
 }
 
 int32_t tt_Node_create_client(struct tt_Node* node, struct tt_Client* client, struct tt_Service* service,
-                              const char* name, tt_CLIENT_CALLBACK callback) {
-    // TODO: Check dup
+                              const char* endpoint_name, tt_CLIENT_CALLBACK callback) {
     struct tt_Endpoint* endpoint = (struct tt_Endpoint*)client;
     endpoint->kind = tt_KIND_SERVICE_CLIENT;
-    endpoint->id = tt_hash_id(service->name, name);
-    endpoint->name = name;
+    endpoint->id = tt_hash_id(service->name, endpoint_name);
+    endpoint->topic_id = 0;
+    endpoint->name = endpoint_name;
     client->node = node;
     client->service = service;
     client->callback = callback;
@@ -256,18 +324,22 @@ int32_t tt_Node_create_client(struct tt_Node* node, struct tt_Client* client, st
     client->cache_time = 0;
     client->latency = 0;
 
-    node->endpoints[node->endpoint_count++] = endpoint;
+    int32_t result = add_endpoint_to_node(node, endpoint);
+    if (result != tt_ERROR_NONE) {
+        return result;
+    }
 
     return 0;
 }
 
 int32_t tt_Node_create_server(struct tt_Node* node, struct tt_Server* server, struct tt_Service* service,
-                              const char* name, tt_SERVER_CALLBACK callback) {
-    // TODO: Check dup
+                              const char* endpoint_name, tt_SERVER_CALLBACK callback) {
     struct tt_Endpoint* endpoint = (struct tt_Endpoint*)server;
     endpoint->kind = tt_KIND_SERVICE_SERVER;
-    endpoint->id = tt_hash_id(service->name, name);
-    endpoint->name = name;
+    endpoint->id = tt_hash_id(service->name, endpoint_name);
+    // Service endpoints are not topic-based, so no topic routing identifier.
+    endpoint->topic_id = 0;
+    endpoint->name = endpoint_name;
     server->node = node;
     server->service = service;
     server->callback = callback;
@@ -276,41 +348,54 @@ int32_t tt_Node_create_server(struct tt_Node* node, struct tt_Server* server, st
         server->cache[i] = NULL;
     }
 
-    node->endpoints[node->endpoint_count++] = endpoint;
+    int32_t result = add_endpoint_to_node(node, endpoint);
+    if (result != tt_ERROR_NONE) {
+        return result;
+    }
     node->last_modified = tt_get_ns();
 
     return 0;
 }
 
 int32_t tt_Node_create_publisher(struct tt_Node* node, struct tt_Publisher* pub, struct tt_Topic* topic,
-                                 const char* name) {
-    // TODO: Check dup
+                                 const char* endpoint_name) {
     struct tt_Endpoint* endpoint = (struct tt_Endpoint*)pub;
     endpoint->kind = tt_KIND_TOPIC_PUBLISHER;
-    endpoint->id = tt_hash_id(topic->name, name);
-    endpoint->name = name;
+    // Unique endpoint identity used for duplicate detection and endpoint lookup.
+    endpoint->id = tt_hash_id(topic->name, endpoint_name);
+    // Topic routing identity shared by all publishers/subscribers of the same topic.
+    endpoint->topic_id = tt_hash_id(topic->name, topic->name);
+    endpoint->name = endpoint_name;
     pub->node = node;
     pub->topic = topic;
     pub->seq_no = 0;
 
-    node->endpoints[node->endpoint_count++] = endpoint;
+    int32_t result = add_endpoint_to_node(node, endpoint);
+    if (result != tt_ERROR_NONE) {
+        return result;
+    }
     node->last_modified = tt_get_ns();
 
     return 0;
 }
 
 int32_t tt_Node_create_subscriber(struct tt_Node* node, struct tt_Subscriber* sub, struct tt_Topic* topic,
-                                  const char* name, tt_SUBSCRIBER_CALLBACK callback) {
-    // TODO: Check dup
+                                  const char* endpoint_name, tt_SUBSCRIBER_CALLBACK callback) {
     struct tt_Endpoint* endpoint = (struct tt_Endpoint*)sub;
     endpoint->kind = tt_KIND_TOPIC_SUBSCRIBER;
-    endpoint->id = tt_hash_id(topic->name, name);
-    endpoint->name = name;
+    // Unique endpoint identity used for duplicate detection and endpoint lookup.
+    endpoint->id = tt_hash_id(topic->name, endpoint_name);
+    // Topic routing identity shared by all publishers/subscribers of the same topic.
+    endpoint->topic_id = tt_hash_id(topic->name, topic->name);
+    endpoint->name = endpoint_name;
     sub->node = node;
     sub->topic = topic;
     sub->callback = callback;
 
-    node->endpoints[node->endpoint_count++] = endpoint;
+    int32_t result = add_endpoint_to_node(node, endpoint);
+    if (result != tt_ERROR_NONE) {
+        return result;
+    }
 
     return 0;
 }
@@ -381,7 +466,7 @@ int32_t tt_Client_call(struct tt_Client* client, struct tt_Request* request) {
         return -1;
     }
 
-    callrequest_header->id = endpoint->id;
+    callrequest_header->endpoint_id = endpoint->id;
     callrequest_header->seq_no = client->seq_no;
     callrequest_header->retry = 0;
 
@@ -441,12 +526,9 @@ int32_t tt_Client_call(struct tt_Client* client, struct tt_Request* request) {
 int32_t tt_Client_destroy(struct tt_Client* client) {
     struct tt_Endpoint* endpoint = (struct tt_Endpoint*)client;
 
-    for (int i = 0; i < client->node->endpoint_count; i++) {
-        if (client->node->endpoints[i] == endpoint) {
-            client->node->endpoints[i] = NULL;
-            client->node->last_modified = tt_get_ns();
-            return 0;
-        }
+    if (remove_endpoint_from_node(client->node, endpoint)) {
+        client->node->last_modified = tt_get_ns();
+        return 0;
     }
 
     return -1;
@@ -455,12 +537,9 @@ int32_t tt_Client_destroy(struct tt_Client* client) {
 int32_t tt_Server_destroy(struct tt_Server* server) {
     struct tt_Endpoint* endpoint = (struct tt_Endpoint*)server;
 
-    for (int i = 0; i < server->node->endpoint_count; i++) {
-        if (server->node->endpoints[i] == endpoint) {
-            server->node->endpoints[i] = NULL;
-            server->node->last_modified = tt_get_ns();
-            return 0;
-        }
+    if (remove_endpoint_from_node(server->node, endpoint)) {
+        server->node->last_modified = tt_get_ns();
+        return 0;
     }
 
     return -1;
@@ -484,7 +563,9 @@ int32_t tt_Publisher_publish(struct tt_Publisher* pub, struct tt_Data* data) {
         return -1;
     }
 
-    data_header->id = endpoint->id;
+    // The embedded endpoint metadata (`endpoint`) caches the shared topic routing id.
+    // Data fan-out is routed by topic, not by the publisher endpoint identity.
+    data_header->topic_id = pub->endpoint.topic_id;
     data_header->seq_no = pub->seq_no + 1;
     data_header->timestamp = tt_get_ns();
 
@@ -515,12 +596,9 @@ int32_t tt_Publisher_publish(struct tt_Publisher* pub, struct tt_Data* data) {
 int32_t tt_Publisher_destroy(struct tt_Publisher* pub) {
     struct tt_Endpoint* endpoint = (struct tt_Endpoint*)pub;
 
-    for (int i = 0; i < pub->node->endpoint_count; i++) {
-        if (pub->node->endpoints[i] == endpoint) {
-            pub->node->endpoints[i] = NULL;
-            pub->node->last_modified = tt_get_ns();
-            return 0;
-        }
+    if (remove_endpoint_from_node(pub->node, endpoint)) {
+        pub->node->last_modified = tt_get_ns();
+        return 0;
     }
 
     return -1;
@@ -529,12 +607,9 @@ int32_t tt_Publisher_destroy(struct tt_Publisher* pub) {
 int32_t tt_Subscriber_destroy(struct tt_Subscriber* sub) {
     struct tt_Endpoint* endpoint = (struct tt_Endpoint*)sub;
 
-    for (int i = 0; i < sub->node->endpoint_count; i++) {
-        if (sub->node->endpoints[i] == endpoint) {
-            sub->node->endpoints[i] = NULL;
-            sub->node->last_modified = tt_get_ns();
-            return 0;
-        }
+    if (remove_endpoint_from_node(sub->node, endpoint)) {
+        sub->node->last_modified = tt_get_ns();
+        return 0;
     }
 
     return -1;
@@ -560,9 +635,20 @@ static void node_update(struct tt_Node* node, uint64_t time, void* param) {
     update_header->last_modified = node->last_modified;
     update_header->entity_count = 0;
 
+    struct tt_Endpoint* endpoints[tt_MAX_ENDPOINT_COUNT];
+    tt_lock_state_t state = lock_endpoints(node);
+    uint32_t endpoint_count = node->endpoint_count;
+    for (uint32_t i = 0; i < endpoint_count; i++) {
+        endpoints[i] = node->endpoints[i];
+    }
+    unlock_endpoints(node, state);
+
     uint8_t entity_count = 0;
-    for (int i = 0; i < node->endpoint_count; i++) {
-        struct tt_Endpoint* endpoint = node->endpoints[i];
+    for (uint32_t i = 0; i < endpoint_count; i++) {
+        struct tt_Endpoint* endpoint = endpoints[i];
+        if (endpoint == NULL) {
+            continue;
+        }
 
         const char* type;
 
@@ -588,7 +674,7 @@ static void node_update(struct tt_Node* node, uint64_t time, void* param) {
             goto done;
         }
 
-        update_entity->id = endpoint->id;
+        update_entity->endpoint_id = endpoint->id;
         update_entity->kind = endpoint->kind;
 
         if (!encode_string(node, type)) {
@@ -604,7 +690,7 @@ static void node_update(struct tt_Node* node, uint64_t time, void* param) {
         }
 
         if (++entity_count == UINT8_MAX) {
-            TT_LOG_WARNING("Maximum update entity: endpoint index: %d, endpoint count: %d", i, node->endpoint_count);
+            TT_LOG_WARNING("Maximum update entity: endpoint index: %u, endpoint count: %u", i, endpoint_count);
             break;
         }
     }
@@ -648,8 +734,8 @@ static bool process_update(struct tt_Node* node, struct tt_Header* header, uint8
     TT_LOG_DEBUG("  update->last_modified = %lu", update_header->last_modified);
     TT_LOG_DEBUG("  update->entity_count = %u", update_header->entity_count);
 
-    if (node->updates[header->source] != NULL &&
-        node->updates[header->source]->last_modified == update_header->last_modified) {
+    if ((node->updates[header->source] != NULL) &&
+        (node->updates[header->source]->last_modified == update_header->last_modified)) {
         return true;
     }
 
@@ -684,7 +770,7 @@ static bool process_update(struct tt_Node* node, struct tt_Header* header, uint8
     for (int i = 0; i < entity_count && head + sizeof(struct tt_UpdateEntity) + (2 * sizeof(uint16_t)) < tail; i++) {
         struct tt_UpdateEntity* update_entity = decode(node, buffer, &head, tail, sizeof(struct tt_UpdateEntity));
 
-        TT_LOG_DEBUG("  update_entity->id = %08x", update_entity->id);
+        TT_LOG_DEBUG("  update_entity->endpoint_id = %08x", update_entity->endpoint_id);
         TT_LOG_DEBUG("  update_entity->kind = %d", update_entity->kind);
 
         uint16_t type_len = 0;
@@ -720,14 +806,28 @@ static bool process_data(struct tt_Node* node, struct tt_Header* header, uint8_t
     }
 
     TT_LOG_DEBUG("  Data");
-    TT_LOG_DEBUG("  id: %08x", data_header->id);
+    TT_LOG_DEBUG("  topic_id: %08x", data_header->topic_id);
     TT_LOG_DEBUG("  timestamp: %ld", data_header->timestamp);
     TT_LOG_DEBUG("  seq_no: %d", data_header->seq_no);
 
-    struct tt_Endpoint* endpoint = find_endpoint(node, tt_KIND_TOPIC_SUBSCRIBER, data_header->id);
-    if (endpoint != NULL) {
-        // Callback
-        struct tt_Subscriber* sub = (struct tt_Subscriber*)endpoint;
+    struct tt_Subscriber* subscribers[tt_MAX_ENDPOINT_COUNT];
+    uint32_t subscriber_count = 0;
+
+    tt_lock_state_t state = lock_endpoints(node);
+    for (uint32_t i = 0; i < node->endpoint_count; i++) {
+        struct tt_Endpoint* endpoint = node->endpoints[i];
+        // Match subscribers by the shared topic routing id carried in the data header.
+        if (endpoint == NULL || endpoint->kind != tt_KIND_TOPIC_SUBSCRIBER ||
+            endpoint->topic_id != data_header->topic_id) {
+            continue;
+        }
+
+        subscribers[subscriber_count++] = (struct tt_Subscriber*)endpoint;
+    }
+    unlock_endpoints(node, state);
+
+    for (uint32_t i = 0; i < subscriber_count; i++) {
+        struct tt_Subscriber* sub = subscribers[i];
         struct tt_Topic* topic = sub->topic;
 
         uint8_t data[topic->data_size];
@@ -736,8 +836,6 @@ static bool process_data(struct tt_Node* node, struct tt_Header* header, uint8_t
         sub->callback(sub, data_header->timestamp, data_header->seq_no, (struct tt_Data*)data);
 
         topic->data_free((struct tt_Data*)data);
-
-        return true;
     }
 
     return true;
@@ -750,7 +848,7 @@ static struct tt_SubmessageHeader* get_server_cache(struct tt_Server* server, ui
             struct tt_CallResponseHeader* callresponse_header =
                 (struct tt_CallResponseHeader*)((void*)submessage_header + sizeof(struct tt_SubmessageHeader));
 
-            if (submessage_header->receiver == receiver && callresponse_header->seq_no == seq_no) {
+            if ((submessage_header->receiver == receiver) && (callresponse_header->seq_no == seq_no)) {
                 return submessage_header;
             }
         }
@@ -806,7 +904,7 @@ static bool set_server_cache(struct tt_Server* server, struct tt_SubmessageHeade
             }
         }
 
-        if (cache != NULL && server->cache[i] == NULL) {
+        if ((cache != NULL) && (server->cache[i] == NULL)) {
             struct tt_CallResponseHeader* callresponse_header =
                 (struct tt_CallResponseHeader*)((void*)cache + sizeof(struct tt_SubmessageHeader));
             server->cache[i] = cache;
@@ -851,11 +949,11 @@ static bool process_callrequest(struct tt_Node* node, struct tt_Header* header, 
     }
 
     TT_LOG_DEBUG("CallRequest");
-    TT_LOG_DEBUG("  id: %08x", callrequest_header->id);
+    TT_LOG_DEBUG("  id: %08x", callrequest_header->endpoint_id);
     TT_LOG_DEBUG("  seq_no: %d", callrequest_header->seq_no);
     TT_LOG_DEBUG("  retry: %d", callrequest_header->retry);
 
-    struct tt_Endpoint* endpoint = find_endpoint(node, tt_KIND_SERVICE_SERVER, callrequest_header->id);
+    struct tt_Endpoint* endpoint = find_endpoint(node, tt_KIND_SERVICE_SERVER, callrequest_header->endpoint_id);
     if (endpoint == NULL) {
         return true;
     }
@@ -908,7 +1006,7 @@ static bool process_callrequest(struct tt_Node* node, struct tt_Header* header, 
             return false;
         }
 
-        call_response_header->id = endpoint->id;
+        call_response_header->endpoint_id = endpoint->id;
         call_response_header->seq_no = callrequest_header->seq_no;
         call_response_header->retry = 0;
         call_response_header->return_code = return_code;
@@ -957,12 +1055,12 @@ static bool process_callresponse(struct tt_Node* node, struct tt_Header* header,
     }
 
     TT_LOG_DEBUG("CallResponse");
-    TT_LOG_DEBUG("  id: %08x", callresponse_header->id);
+    TT_LOG_DEBUG("  id: %08x", callresponse_header->endpoint_id);
     TT_LOG_DEBUG("  seq_no: %d", callresponse_header->seq_no);
     TT_LOG_DEBUG("  retry: %d", callresponse_header->retry);
     TT_LOG_DEBUG("  return_code: %d", callresponse_header->return_code);
 
-    struct tt_Endpoint* endpoint = find_endpoint(node, tt_KIND_SERVICE_CLIENT, callresponse_header->id);
+    struct tt_Endpoint* endpoint = find_endpoint(node, tt_KIND_SERVICE_CLIENT, callresponse_header->endpoint_id);
     if (endpoint == NULL) {
         return true;
     }
@@ -1133,7 +1231,7 @@ int32_t tt_Node_poll(struct tt_Node* node) {
         uint64_t time = tt_get_ns();
         struct tt_TCB* tcb = peek_scheduler(node);
 
-        if (tcb != NULL && tcb->time <= time) {
+        if ((tcb != NULL) && (tcb->time <= time)) {
             tcb->function(node, time, tcb->param);
             pop_scheduler(node);
         }
@@ -1145,18 +1243,22 @@ int32_t tt_Node_poll(struct tt_Node* node) {
 int32_t tt_Node_destroy(struct tt_Node* node) {
     uint64_t time = tt_get_ns();
 
-    for (int i = 0; i < node->endpoint_count; i++) {
+    tt_lock_state_t state = lock_endpoints(node);
+    for (uint32_t i = 0; i < node->endpoint_count; i++) {
         struct tt_Endpoint* endpoint = node->endpoints[i];
         node->endpoints[i] = NULL;
 
-        if (endpoint != NULL && (endpoint->kind & tt_KIND_SENDER) == tt_KIND_SENDER) {
+        if ((endpoint != NULL) && ((endpoint->kind & tt_KIND_SENDER) == tt_KIND_SENDER)) {
             node->last_modified = time;
         }
     }
+    node->endpoint_count = 0;
+    unlock_endpoints(node, state);
 
     node_update(node, time, NULL);
 
     tt_close(node);
+    tt_lock_deinit(&node->endpoint_lock);
 
     return 0;
 }

--- a/src/tickle.c
+++ b/src/tickle.c
@@ -813,6 +813,8 @@ static bool process_data(struct tt_Node* node, struct tt_Header* header, uint8_t
     struct tt_Subscriber* subscribers[tt_MAX_ENDPOINT_COUNT];
     uint32_t subscriber_count = 0;
 
+    // Snapshot matching subscribers while the endpoint registry is protected.
+    // Callbacks run after unlock so user code can create or remove endpoints without deadlocking.
     tt_lock_state_t state = lock_endpoints(node);
     for (uint32_t i = 0; i < node->endpoint_count; i++) {
         struct tt_Endpoint* endpoint = node->endpoints[i];

--- a/tests/test_callresponse.c
+++ b/tests/test_callresponse.c
@@ -45,8 +45,8 @@ static void test_callresponse_updates_latency_from_cache_time_to_now(void) {
 
     struct tt_Client client;
     memset(&client, 0, sizeof(client));
-    client.super.kind = tt_KIND_SERVICE_CLIENT;
-    client.super.id = test_client_id;
+    client.endpoint.kind = tt_KIND_SERVICE_CLIENT;
+    client.endpoint.id = test_client_id;
     client.service = &service;
     client.callback = test_client_callback;
     client.cache = malloc(1);
@@ -65,7 +65,7 @@ static void test_callresponse_updates_latency_from_cache_time_to_now(void) {
 
     struct tt_CallResponseHeader response_header;
     memset(&response_header, 0, sizeof(response_header));
-    response_header.id = client.super.id;
+    response_header.endpoint_id = client.endpoint.id;
     response_header.seq_no = test_response_seq_no;
     response_header.return_code = (int8_t)test_return_code;
 

--- a/tests/test_endpoint.c
+++ b/tests/test_endpoint.c
@@ -7,6 +7,7 @@
 #include <tickle/tickle.h>
 
 static const uint32_t k_test_endpoint_id = 0x1234;
+static const uint64_t k_test_data_timestamp = 1234;
 static struct tt_Endpoint* find_endpoint(struct tt_Node* node, uint8_t kind, uint32_t endpoint_id);
 static int32_t add_endpoint_to_node(struct tt_Node* node, struct tt_Endpoint* endpoint);
 static bool remove_endpoint_from_node(struct tt_Node* node, struct tt_Endpoint* endpoint);
@@ -145,6 +146,22 @@ static void test_find_endpoint_locks_endpoint_registry(void) {
     EXPECT_TRUE(test_mock_last_lock == &node.endpoint_lock);
 }
 
+static void expect_endpoint_registry_shifted_after_middle_remove(const struct tt_Node* node,
+                                                                 const struct tt_Endpoint* endpoint1,
+                                                                 const struct tt_Endpoint* endpoint3) {
+    EXPECT_EQ_U32(2, node->endpoint_count);
+    EXPECT_TRUE(node->endpoints[0] == endpoint1);
+    EXPECT_TRUE(node->endpoints[1] == endpoint3);
+    EXPECT_TRUE(node->endpoints[2] == NULL);
+}
+
+static void expect_endpoint_registry_lock_used(const struct tt_Node* node) {
+    EXPECT_EQ_U32(1, test_mock_lock_count);
+    EXPECT_EQ_U32(1, test_mock_unlock_count);
+    EXPECT_EQ_U32(0, test_mock_lock_depth);
+    EXPECT_TRUE(test_mock_last_lock == &node->endpoint_lock);
+}
+
 static void test_remove_endpoint_from_node_locks_and_shifts_endpoint_registry(void) {
     struct tt_Node node;
     memset(&node, 0, sizeof(node));
@@ -161,14 +178,8 @@ static void test_remove_endpoint_from_node_locks_and_shifts_endpoint_registry(vo
     test_mock_reset();
 
     EXPECT_TRUE(remove_endpoint_from_node(&node, &endpoint2));
-    EXPECT_EQ_U32(2, node.endpoint_count);
-    EXPECT_TRUE(node.endpoints[0] == &endpoint1);
-    EXPECT_TRUE(node.endpoints[1] == &endpoint3);
-    EXPECT_TRUE(node.endpoints[2] == NULL);
-    EXPECT_EQ_U32(1, test_mock_lock_count);
-    EXPECT_EQ_U32(1, test_mock_unlock_count);
-    EXPECT_EQ_U32(0, test_mock_lock_depth);
-    EXPECT_TRUE(test_mock_last_lock == &node.endpoint_lock);
+    expect_endpoint_registry_shifted_after_middle_remove(&node, &endpoint1, &endpoint3);
+    expect_endpoint_registry_lock_used(&node);
 }
 
 static void test_tt_node_create_cleans_up_endpoint_lock_on_invalid_node_id(void) {
@@ -333,7 +344,7 @@ static int32_t test_data_decode(struct tt_Data* data, const uint8_t* payload, co
                                 bool is_native_endian) {
     (void)is_native_endian;
     _tt_memcpy(data, payload, len);
-    return len;
+    return (int32_t)len;
 }
 
 static void test_data_free(struct tt_Data* data) {
@@ -455,6 +466,11 @@ static void test_tt_node_create_subscriber_allows_multiple_endpoints_same_topic(
     EXPECT_TRUE(node.endpoints[1] == (struct tt_Endpoint*)&sub2);
 }
 
+static void expect_two_subscribers_dispatched(void) {
+    EXPECT_TRUE(g_sub1_invocations == 1);
+    EXPECT_TRUE(g_sub2_invocations == 1);
+}
+
 static void test_process_data_dispatches_same_topic_to_multiple_subscribers(void) {
     struct tt_Node node;
     memset(&node, 0, sizeof(node));
@@ -489,7 +505,7 @@ static void test_process_data_dispatches_same_topic_to_multiple_subscribers(void
     struct tt_DataHeader* data_header = (struct tt_DataHeader*)buffer;
     data_header->topic_id = tt_hash_id(topic.name, topic.name);
     data_header->seq_no = 1;
-    data_header->timestamp = 1234;
+    data_header->timestamp = k_test_data_timestamp;
     buffer[sizeof(struct tt_DataHeader) + 0] = 0x01;
     buffer[sizeof(struct tt_DataHeader) + 1] = 0x02;
     buffer[sizeof(struct tt_DataHeader) + 2] = 0x03;
@@ -500,14 +516,10 @@ static void test_process_data_dispatches_same_topic_to_multiple_subscribers(void
     header.version = tt_VERSION;
     header.source = 0;
 
-    bool ok = process_data(&node, &header, buffer, 0, sizeof(buffer));
-    EXPECT_TRUE(ok);
-    EXPECT_TRUE(g_sub1_invocations == 1);
-    EXPECT_TRUE(g_sub2_invocations == 1);
-    EXPECT_EQ_U32(1, test_mock_lock_count);
-    EXPECT_EQ_U32(1, test_mock_unlock_count);
-    EXPECT_EQ_U32(0, test_mock_lock_depth);
-    EXPECT_TRUE(test_mock_last_lock == &node.endpoint_lock);
+    bool process_ok = process_data(&node, &header, buffer, 0, sizeof(buffer));
+    EXPECT_TRUE(process_ok);
+    expect_two_subscribers_dispatched();
+    expect_endpoint_registry_lock_used(&node);
 }
 
 static void test_create_functions_return_too_many_when_endpoint_limit_reached(void) {

--- a/tests/test_endpoint.c
+++ b/tests/test_endpoint.c
@@ -1,0 +1,573 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <tickle/config.h>
+#include <tickle/hal.h>
+#include <tickle/tickle.h>
+
+static const uint32_t k_test_endpoint_id = 0x1234;
+static struct tt_Endpoint* find_endpoint(struct tt_Node* node, uint8_t kind, uint32_t endpoint_id);
+static int32_t add_endpoint_to_node(struct tt_Node* node, struct tt_Endpoint* endpoint);
+static bool remove_endpoint_from_node(struct tt_Node* node, struct tt_Endpoint* endpoint);
+static bool process_data(struct tt_Node* node, struct tt_Header* header, uint8_t* buffer, uint32_t head, uint32_t tail);
+static bool process_callrequest(struct tt_Node* node, struct tt_Header* header, uint8_t* buffer, uint32_t head,
+                                uint32_t tail);
+
+// This file owns the shared test assertion state for this test binary.
+#define TEST_COMMON_DEFINE_STORAGE
+#include "test_common.h"
+
+// This file owns the HAL/time mocks used by the included tickle.c implementation.
+#define TEST_MOCK_DEFINE_STORAGE
+#include "test_mock.h" // NOLINT(misc-include-cleaner)
+
+static void test_add_endpoint_to_node_success(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+
+    struct tt_Endpoint endpoint;
+    endpoint.kind = tt_KIND_TOPIC_PUBLISHER;
+    endpoint.id = k_test_endpoint_id;
+    endpoint.name = "topic_pub";
+
+    int32_t result = add_endpoint_to_node(&node, &endpoint);
+    EXPECT_TRUE(result == tt_ERROR_NONE);
+    EXPECT_EQ_U32(1, node.endpoint_count);
+    EXPECT_TRUE(node.endpoints[0] == &endpoint);
+}
+
+static void test_add_endpoint_to_node_too_many_endpoints(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+    node.endpoint_count = tt_MAX_ENDPOINT_COUNT;
+
+    struct tt_Endpoint endpoint;
+    endpoint.kind = tt_KIND_TOPIC_PUBLISHER;
+    endpoint.id = k_test_endpoint_id;
+    endpoint.name = "topic_pub";
+
+    int32_t result = add_endpoint_to_node(&node, &endpoint);
+    EXPECT_TRUE(result == tt_TOO_MANY_ENDPOINTS);
+    EXPECT_EQ_U32(tt_MAX_ENDPOINT_COUNT, node.endpoint_count);
+}
+
+static void test_add_endpoint_to_node_duplicate_returns_duplicate_endpoint(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+
+    struct tt_Endpoint endpoint1;
+    endpoint1.kind = tt_KIND_SERVICE_SERVER;
+    endpoint1.id = k_test_endpoint_id;
+    endpoint1.name = "server";
+
+    struct tt_Endpoint endpoint2 = endpoint1;
+
+    EXPECT_TRUE(add_endpoint_to_node(&node, &endpoint1) == tt_ERROR_NONE);
+    EXPECT_TRUE(add_endpoint_to_node(&node, &endpoint2) == tt_DUPLICATE_ENDPOINT);
+    EXPECT_EQ_U32(1, node.endpoint_count);
+}
+
+static void test_add_endpoint_to_node_allows_same_topic_subscribers(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+
+    struct tt_Endpoint subscriber1 = {.kind = tt_KIND_TOPIC_SUBSCRIBER,
+                                      .id = tt_hash_id("topic", "subscriber1"),
+                                      .name = "subscriber1"};
+    struct tt_Endpoint subscriber2 = {.kind = tt_KIND_TOPIC_SUBSCRIBER,
+                                      .id = tt_hash_id("topic", "subscriber2"),
+                                      .name = "subscriber2"};
+
+    EXPECT_TRUE(add_endpoint_to_node(&node, &subscriber1) == tt_ERROR_NONE);
+    EXPECT_TRUE(add_endpoint_to_node(&node, &subscriber2) == tt_ERROR_NONE);
+    EXPECT_EQ_U32(2, node.endpoint_count);
+    EXPECT_TRUE(node.endpoints[0] == &subscriber1);
+    EXPECT_TRUE(node.endpoints[1] == &subscriber2);
+}
+
+static void test_add_endpoint_to_node_locks_endpoint_registry(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+
+    struct tt_Endpoint endpoint;
+    endpoint.kind = tt_KIND_TOPIC_PUBLISHER;
+    endpoint.id = k_test_endpoint_id;
+    endpoint.name = "topic_pub";
+
+    test_mock_reset();
+
+    EXPECT_TRUE(add_endpoint_to_node(&node, &endpoint) == tt_ERROR_NONE);
+    EXPECT_EQ_U32(1, test_mock_lock_count);
+    EXPECT_EQ_U32(1, test_mock_unlock_count);
+    EXPECT_EQ_U32(0, test_mock_lock_depth);
+    EXPECT_EQ_U32(1, test_mock_max_lock_depth);
+    EXPECT_TRUE(test_mock_last_lock == &node.endpoint_lock);
+}
+
+static void test_add_endpoint_to_node_unlocks_on_error(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+    node.endpoint_count = tt_MAX_ENDPOINT_COUNT;
+
+    struct tt_Endpoint endpoint;
+    endpoint.kind = tt_KIND_TOPIC_PUBLISHER;
+    endpoint.id = k_test_endpoint_id;
+    endpoint.name = "topic_pub";
+
+    test_mock_reset();
+
+    EXPECT_TRUE(add_endpoint_to_node(&node, &endpoint) == tt_TOO_MANY_ENDPOINTS);
+    EXPECT_EQ_U32(1, test_mock_lock_count);
+    EXPECT_EQ_U32(1, test_mock_unlock_count);
+    EXPECT_EQ_U32(0, test_mock_lock_depth);
+    EXPECT_TRUE(test_mock_last_lock == &node.endpoint_lock);
+}
+
+static void test_find_endpoint_locks_endpoint_registry(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+
+    struct tt_Endpoint endpoint;
+    endpoint.kind = tt_KIND_SERVICE_SERVER;
+    endpoint.id = k_test_endpoint_id;
+    endpoint.name = "server";
+
+    node.endpoint_count = 1;
+    node.endpoints[0] = &endpoint;
+
+    test_mock_reset();
+
+    EXPECT_TRUE(find_endpoint(&node, endpoint.kind, endpoint.id) == &endpoint);
+    EXPECT_EQ_U32(1, test_mock_lock_count);
+    EXPECT_EQ_U32(1, test_mock_unlock_count);
+    EXPECT_EQ_U32(0, test_mock_lock_depth);
+    EXPECT_TRUE(test_mock_last_lock == &node.endpoint_lock);
+}
+
+static void test_remove_endpoint_from_node_locks_and_shifts_endpoint_registry(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+
+    struct tt_Endpoint endpoint1 = {.kind = tt_KIND_TOPIC_PUBLISHER, .id = 1, .name = "publisher1"};
+    struct tt_Endpoint endpoint2 = {.kind = tt_KIND_TOPIC_PUBLISHER, .id = 2, .name = "publisher2"};
+    struct tt_Endpoint endpoint3 = {.kind = tt_KIND_TOPIC_PUBLISHER, .id = 3, .name = "publisher3"};
+
+    node.endpoint_count = 3;
+    node.endpoints[0] = &endpoint1;
+    node.endpoints[1] = &endpoint2;
+    node.endpoints[2] = &endpoint3;
+
+    test_mock_reset();
+
+    EXPECT_TRUE(remove_endpoint_from_node(&node, &endpoint2));
+    EXPECT_EQ_U32(2, node.endpoint_count);
+    EXPECT_TRUE(node.endpoints[0] == &endpoint1);
+    EXPECT_TRUE(node.endpoints[1] == &endpoint3);
+    EXPECT_TRUE(node.endpoints[2] == NULL);
+    EXPECT_EQ_U32(1, test_mock_lock_count);
+    EXPECT_EQ_U32(1, test_mock_unlock_count);
+    EXPECT_EQ_U32(0, test_mock_lock_depth);
+    EXPECT_TRUE(test_mock_last_lock == &node.endpoint_lock);
+}
+
+static void test_tt_node_create_cleans_up_endpoint_lock_on_invalid_node_id(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+
+    test_mock_reset();
+    test_mock_node_id = tt_NODE_ID_INVALID;
+
+    EXPECT_TRUE(tt_Node_create(&node) == -2);
+    EXPECT_EQ_U32(1, test_mock_lock_init_count);
+    EXPECT_EQ_U32(1, test_mock_lock_deinit_count);
+    EXPECT_TRUE(test_mock_last_lock == &node.endpoint_lock);
+}
+
+static void test_tt_node_create_client_adds_endpoint(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+
+    struct tt_Service service;
+    memset(&service, 0, sizeof(service));
+    service.name = "service";
+
+    struct tt_Client client;
+    memset(&client, 0, sizeof(client));
+
+    int32_t result = tt_Node_create_client(&node, &client, &service, "client", NULL);
+    EXPECT_TRUE(result == tt_ERROR_NONE);
+    EXPECT_EQ_U32(1, node.endpoint_count);
+    EXPECT_TRUE(node.endpoints[0] == (struct tt_Endpoint*)&client);
+}
+
+static void test_tt_node_create_server_adds_endpoint(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+
+    struct tt_Service service;
+    memset(&service, 0, sizeof(service));
+    service.name = "service";
+
+    struct tt_Server server;
+    memset(&server, 0, sizeof(server));
+
+    int32_t result = tt_Node_create_server(&node, &server, &service, "server", NULL);
+    EXPECT_TRUE(result == tt_ERROR_NONE);
+    EXPECT_EQ_U32(1, node.endpoint_count);
+    EXPECT_TRUE(node.endpoints[0] == (struct tt_Endpoint*)&server);
+}
+
+static void test_tt_node_create_publisher_adds_endpoint(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+
+    struct tt_Topic topic;
+    memset(&topic, 0, sizeof(topic));
+    topic.name = "topic";
+
+    struct tt_Publisher pub;
+    memset(&pub, 0, sizeof(pub));
+
+    int32_t result = tt_Node_create_publisher(&node, &pub, &topic, "publisher");
+    EXPECT_TRUE(result == tt_ERROR_NONE);
+    EXPECT_EQ_U32(1, node.endpoint_count);
+    EXPECT_TRUE(node.endpoints[0] == (struct tt_Endpoint*)&pub);
+}
+
+static void test_tt_node_create_subscriber_adds_endpoint(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+
+    struct tt_Topic topic;
+    memset(&topic, 0, sizeof(topic));
+    topic.name = "topic";
+
+    struct tt_Subscriber sub;
+    memset(&sub, 0, sizeof(sub));
+
+    int32_t result = tt_Node_create_subscriber(&node, &sub, &topic, "subscriber", NULL);
+    EXPECT_TRUE(result == tt_ERROR_NONE);
+    EXPECT_EQ_U32(1, node.endpoint_count);
+    EXPECT_TRUE(node.endpoints[0] == (struct tt_Endpoint*)&sub);
+}
+
+static void test_tt_node_create_publisher_allows_multiple_endpoints_same_topic(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+
+    struct tt_Topic topic;
+    memset(&topic, 0, sizeof(topic));
+    topic.name = "topic";
+
+    struct tt_Publisher pub1;
+    memset(&pub1, 0, sizeof(pub1));
+    struct tt_Publisher pub2;
+    memset(&pub2, 0, sizeof(pub2));
+
+    EXPECT_TRUE(tt_Node_create_publisher(&node, &pub1, &topic, "publisher1") == tt_ERROR_NONE);
+    EXPECT_TRUE(tt_Node_create_publisher(&node, &pub2, &topic, "publisher2") == tt_ERROR_NONE);
+    EXPECT_EQ_U32(2, node.endpoint_count);
+    EXPECT_TRUE(node.endpoints[0] == (struct tt_Endpoint*)&pub1);
+    EXPECT_TRUE(node.endpoints[1] == (struct tt_Endpoint*)&pub2);
+}
+
+static void test_tt_node_create_client_duplicate_returns_duplicate_endpoint(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+
+    struct tt_Service service;
+    memset(&service, 0, sizeof(service));
+    service.name = "service";
+
+    struct tt_Client client1;
+    memset(&client1, 0, sizeof(client1));
+    struct tt_Client client2;
+    memset(&client2, 0, sizeof(client2));
+
+    EXPECT_TRUE(tt_Node_create_client(&node, &client1, &service, "client", NULL) == tt_ERROR_NONE);
+    EXPECT_TRUE(tt_Node_create_client(&node, &client2, &service, "client", NULL) == tt_DUPLICATE_ENDPOINT);
+    EXPECT_EQ_U32(1, node.endpoint_count);
+}
+
+static void test_tt_node_create_server_duplicate_returns_duplicate_endpoint(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+
+    struct tt_Service service;
+    memset(&service, 0, sizeof(service));
+    service.name = "service";
+
+    struct tt_Server server1;
+    memset(&server1, 0, sizeof(server1));
+    struct tt_Server server2;
+    memset(&server2, 0, sizeof(server2));
+
+    EXPECT_TRUE(tt_Node_create_server(&node, &server1, &service, "server", NULL) == tt_ERROR_NONE);
+    EXPECT_TRUE(tt_Node_create_server(&node, &server2, &service, "server", NULL) == tt_DUPLICATE_ENDPOINT);
+    EXPECT_EQ_U32(1, node.endpoint_count);
+}
+
+static int g_sub1_invocations;
+static int g_sub2_invocations;
+
+static void test_subscriber_callback1(struct tt_Subscriber* subscriber, uint64_t time, uint16_t seq_no,
+                                      struct tt_Data* data) {
+    (void)subscriber;
+    (void)time;
+    (void)seq_no;
+    (void)data;
+    g_sub1_invocations++;
+}
+
+static void test_subscriber_callback2(struct tt_Subscriber* subscriber, uint64_t time, uint16_t seq_no,
+                                      struct tt_Data* data) {
+    (void)subscriber;
+    (void)time;
+    (void)seq_no;
+    (void)data;
+    g_sub2_invocations++;
+}
+
+static int32_t test_data_decode(struct tt_Data* data, const uint8_t* payload, const uint32_t len,
+                                bool is_native_endian) {
+    (void)is_native_endian;
+    _tt_memcpy(data, payload, len);
+    return len;
+}
+
+static void test_data_free(struct tt_Data* data) {
+    (void)data;
+}
+
+static int g_server1_invocations;
+static int g_server2_invocations;
+
+static int8_t test_server_callback1(struct tt_Server* server, struct tt_Request* request,
+                                    struct tt_Response* response) {
+    (void)server;
+    (void)request;
+    (void)response;
+    g_server1_invocations++;
+    return 1;
+}
+
+static int8_t test_server_callback2(struct tt_Server* server, struct tt_Request* request,
+                                    struct tt_Response* response) {
+    (void)server;
+    (void)request;
+    (void)response;
+    g_server2_invocations++;
+    return 1;
+}
+
+static int32_t test_request_decode(struct tt_Request* request, const uint8_t* payload, const uint32_t len,
+                                   bool is_native_endian) {
+    (void)request;
+    (void)payload;
+    (void)len;
+    (void)is_native_endian;
+    return 0;
+}
+
+static void test_request_free(struct tt_Request* request) {
+    (void)request;
+}
+
+static void test_process_callrequest_finds_correct_service_server_endpoint(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+    node.tx_size = tt_MAX_BUFFER_LENGTH;
+    node.tx_tail = 0;
+
+    struct tt_Service service1;
+    memset(&service1, 0, sizeof(service1));
+    service1.name = "service1";
+    service1.request_decode = test_request_decode;
+    service1.request_free = test_request_free;
+
+    struct tt_Service service2;
+    memset(&service2, 0, sizeof(service2));
+    service2.name = "service2";
+    service2.request_decode = test_request_decode;
+    service2.request_free = test_request_free;
+
+    struct tt_Server server1;
+    memset(&server1, 0, sizeof(server1));
+    server1.endpoint.kind = tt_KIND_SERVICE_SERVER;
+    server1.endpoint.id = tt_hash_id("service1", "server1");
+    server1.node = &node;
+    server1.service = &service1;
+    server1.callback = test_server_callback1;
+
+    struct tt_Server server2;
+    memset(&server2, 0, sizeof(server2));
+    server2.endpoint.kind = tt_KIND_SERVICE_SERVER;
+    server2.endpoint.id = tt_hash_id("service2", "server2");
+    server2.node = &node;
+    server2.service = &service2;
+    server2.callback = test_server_callback2;
+
+    node.endpoint_count = 2;
+    node.endpoints[0] = (struct tt_Endpoint*)&server1;
+    node.endpoints[1] = (struct tt_Endpoint*)&server2;
+
+    struct tt_CallRequestHeader request_header;
+    memset(&request_header, 0, sizeof(request_header));
+    request_header.endpoint_id = server2.endpoint.id;
+    request_header.seq_no = 1;
+    request_header.retry = 0;
+
+    uint8_t buffer[sizeof(request_header)];
+    memcpy(buffer, &request_header, sizeof(request_header));
+
+    struct tt_Header header;
+    header.magic_value = NATIVE_MAGIC_VALUE;
+    header.version = tt_VERSION;
+    header.source = 1;
+
+    g_server1_invocations = 0;
+    g_server2_invocations = 0;
+    test_mock_reset();
+
+    EXPECT_TRUE(process_callrequest(&node, &header, buffer, 0, sizeof(buffer)));
+    EXPECT_EQ_U32(0, g_server1_invocations);
+    EXPECT_EQ_U32(1, g_server2_invocations);
+}
+
+static void test_tt_node_create_subscriber_allows_multiple_endpoints_same_topic(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+
+    struct tt_Topic topic;
+    memset(&topic, 0, sizeof(topic));
+    topic.name = "topic";
+
+    struct tt_Subscriber sub1;
+    memset(&sub1, 0, sizeof(sub1));
+    struct tt_Subscriber sub2;
+    memset(&sub2, 0, sizeof(sub2));
+
+    EXPECT_TRUE(tt_Node_create_subscriber(&node, &sub1, &topic, "subscriber1", NULL) == tt_ERROR_NONE);
+    EXPECT_TRUE(tt_Node_create_subscriber(&node, &sub2, &topic, "subscriber2", NULL) == tt_ERROR_NONE);
+    EXPECT_EQ_U32(2, node.endpoint_count);
+    EXPECT_TRUE(node.endpoints[0] == (struct tt_Endpoint*)&sub1);
+    EXPECT_TRUE(node.endpoints[1] == (struct tt_Endpoint*)&sub2);
+}
+
+static void test_process_data_dispatches_same_topic_to_multiple_subscribers(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+
+    struct tt_Topic topic;
+    memset(&topic, 0, sizeof(topic));
+    topic.name = "topic";
+    topic.data_size = 4;
+    topic.data_decode = test_data_decode;
+    topic.data_free = test_data_free;
+
+    struct tt_Subscriber sub1;
+    memset(&sub1, 0, sizeof(sub1));
+    struct tt_Subscriber sub2;
+    memset(&sub2, 0, sizeof(sub2));
+
+    sub1.topic = &topic;
+    sub1.callback = test_subscriber_callback1;
+    sub2.topic = &topic;
+    sub2.callback = test_subscriber_callback2;
+
+    int32_t result1 = tt_Node_create_subscriber(&node, &sub1, &topic, "subscriber1", test_subscriber_callback1);
+    int32_t result2 = tt_Node_create_subscriber(&node, &sub2, &topic, "subscriber2", test_subscriber_callback2);
+    EXPECT_TRUE(result1 == tt_ERROR_NONE);
+    EXPECT_TRUE(result2 == tt_ERROR_NONE);
+
+    g_sub1_invocations = 0;
+    g_sub2_invocations = 0;
+    test_mock_reset();
+
+    uint8_t buffer[sizeof(struct tt_DataHeader) + 4];
+    struct tt_DataHeader* data_header = (struct tt_DataHeader*)buffer;
+    data_header->topic_id = tt_hash_id(topic.name, topic.name);
+    data_header->seq_no = 1;
+    data_header->timestamp = 1234;
+    buffer[sizeof(struct tt_DataHeader) + 0] = 0x01;
+    buffer[sizeof(struct tt_DataHeader) + 1] = 0x02;
+    buffer[sizeof(struct tt_DataHeader) + 2] = 0x03;
+    buffer[sizeof(struct tt_DataHeader) + 3] = 0x04;
+
+    struct tt_Header header;
+    header.magic_value = NATIVE_MAGIC_VALUE;
+    header.version = tt_VERSION;
+    header.source = 0;
+
+    bool ok = process_data(&node, &header, buffer, 0, sizeof(buffer));
+    EXPECT_TRUE(ok);
+    EXPECT_TRUE(g_sub1_invocations == 1);
+    EXPECT_TRUE(g_sub2_invocations == 1);
+    EXPECT_EQ_U32(1, test_mock_lock_count);
+    EXPECT_EQ_U32(1, test_mock_unlock_count);
+    EXPECT_EQ_U32(0, test_mock_lock_depth);
+    EXPECT_TRUE(test_mock_last_lock == &node.endpoint_lock);
+}
+
+static void test_create_functions_return_too_many_when_endpoint_limit_reached(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+    node.endpoint_count = tt_MAX_ENDPOINT_COUNT;
+
+    struct tt_Service service;
+    memset(&service, 0, sizeof(service));
+    service.name = "service";
+
+    struct tt_Topic topic;
+    memset(&topic, 0, sizeof(topic));
+    topic.name = "topic";
+
+    struct tt_Client client;
+    memset(&client, 0, sizeof(client));
+    struct tt_Server server;
+    memset(&server, 0, sizeof(server));
+    struct tt_Publisher pub;
+    memset(&pub, 0, sizeof(pub));
+    struct tt_Subscriber sub;
+    memset(&sub, 0, sizeof(sub));
+
+    EXPECT_TRUE(tt_Node_create_client(&node, &client, &service, "client", NULL) == tt_TOO_MANY_ENDPOINTS);
+    EXPECT_TRUE(tt_Node_create_server(&node, &server, &service, "server", NULL) == tt_TOO_MANY_ENDPOINTS);
+    EXPECT_TRUE(tt_Node_create_publisher(&node, &pub, &topic, "publisher") == tt_TOO_MANY_ENDPOINTS);
+    EXPECT_TRUE(tt_Node_create_subscriber(&node, &sub, &topic, "subscriber", NULL) == tt_TOO_MANY_ENDPOINTS);
+}
+
+// Include the implementation to exercise static helper and create functions directly.
+// NOLINTNEXTLINE(bugprone-suspicious-include)
+#include "../src/tickle.c"
+
+int main(void) {
+    test_add_endpoint_to_node_success();
+    test_add_endpoint_to_node_too_many_endpoints();
+    test_add_endpoint_to_node_duplicate_returns_duplicate_endpoint();
+    test_add_endpoint_to_node_allows_same_topic_subscribers();
+    test_add_endpoint_to_node_locks_endpoint_registry();
+    test_add_endpoint_to_node_unlocks_on_error();
+    test_find_endpoint_locks_endpoint_registry();
+    test_remove_endpoint_from_node_locks_and_shifts_endpoint_registry();
+    test_tt_node_create_cleans_up_endpoint_lock_on_invalid_node_id();
+    test_tt_node_create_client_adds_endpoint();
+    test_tt_node_create_client_duplicate_returns_duplicate_endpoint();
+    test_tt_node_create_server_adds_endpoint();
+    test_tt_node_create_server_duplicate_returns_duplicate_endpoint();
+    test_tt_node_create_publisher_adds_endpoint();
+    test_tt_node_create_publisher_allows_multiple_endpoints_same_topic();
+    test_tt_node_create_subscriber_adds_endpoint();
+    test_tt_node_create_subscriber_allows_multiple_endpoints_same_topic();
+    test_process_data_dispatches_same_topic_to_multiple_subscribers();
+    test_process_callrequest_finds_correct_service_server_endpoint();
+    test_create_functions_return_too_many_when_endpoint_limit_reached();
+
+    if (test_result() != 0) {
+        return 1;
+    }
+
+    printf("endpoint tests passed\n");
+    return 0;
+}

--- a/tests/test_mock.h
+++ b/tests/test_mock.h
@@ -25,6 +25,13 @@ int32_t test_mock_bind_return = 0;
 int32_t test_mock_receive_return = -1;
 bool test_mock_send_return_override = false;
 int32_t test_mock_send_return = 0;
+int32_t test_mock_lock_init_count = 0;
+int32_t test_mock_lock_deinit_count = 0;
+int32_t test_mock_lock_count = 0;
+int32_t test_mock_unlock_count = 0;
+int32_t test_mock_lock_depth = 0;
+int32_t test_mock_max_lock_depth = 0;
+tt_lock_t* test_mock_last_lock = NULL;
 #else
 extern uint64_t test_mock_now;
 extern int32_t test_mock_node_id;
@@ -32,6 +39,13 @@ extern int32_t test_mock_bind_return;
 extern int32_t test_mock_receive_return;
 extern bool test_mock_send_return_override;
 extern int32_t test_mock_send_return;
+extern int32_t test_mock_lock_init_count;
+extern int32_t test_mock_lock_deinit_count;
+extern int32_t test_mock_lock_count;
+extern int32_t test_mock_unlock_count;
+extern int32_t test_mock_lock_depth;
+extern int32_t test_mock_max_lock_depth;
+extern tt_lock_t* test_mock_last_lock;
 #endif
 
 // Tests may override these globals after reset to drive specific timing or HAL outcomes.
@@ -42,6 +56,13 @@ static inline void test_mock_reset(void) {
     test_mock_receive_return = -1;
     test_mock_send_return_override = false;
     test_mock_send_return = 0;
+    test_mock_lock_init_count = 0;
+    test_mock_lock_deinit_count = 0;
+    test_mock_lock_count = 0;
+    test_mock_unlock_count = 0;
+    test_mock_lock_depth = 0;
+    test_mock_max_lock_depth = 0;
+    test_mock_last_lock = NULL;
 }
 
 #ifdef TEST_MOCK_DEFINE_STORAGE
@@ -61,6 +82,33 @@ int32_t tt_bind(struct tt_Node* node) {
 
 void tt_close(struct tt_Node* node) {
     (void)node;
+}
+
+void tt_lock_init(tt_lock_t* lock) {
+    test_mock_lock_init_count++;
+    test_mock_last_lock = lock;
+}
+
+void tt_lock_deinit(tt_lock_t* lock) {
+    test_mock_lock_deinit_count++;
+    test_mock_last_lock = lock;
+}
+
+tt_lock_state_t tt_lock(tt_lock_t* lock) {
+    test_mock_lock_count++;
+    test_mock_lock_depth++;
+    if (test_mock_lock_depth > test_mock_max_lock_depth) {
+        test_mock_max_lock_depth = test_mock_lock_depth;
+    }
+    test_mock_last_lock = lock;
+    return 0;
+}
+
+void tt_unlock(tt_lock_t* lock, tt_lock_state_t state) {
+    (void)state;
+    test_mock_unlock_count++;
+    test_mock_lock_depth--;
+    test_mock_last_lock = lock;
 }
 
 int32_t tt_send(struct tt_Node* node, const void* buf, size_t len) {

--- a/tests/test_mock.h
+++ b/tests/test_mock.h
@@ -8,6 +8,7 @@
 #include <stdint.h>
 
 #include <tickle/config.h> // NOLINT(misc-include-cleaner)
+#include <tickle/hal.h>    // NOLINT(misc-include-cleaner)
 #include <tickle/tickle.h> // NOLINT(misc-include-cleaner)
 
 // Define mock HAL symbols in one test binary so tickle.c can be included directly.


### PR DESCRIPTION
**1. Purpose**

Improve node creation validation by adding endpoint limits, reserved node ID checks, topic-based endpoint routing, and endpoint registry locking.

**2. Overview**

- Add tt_MAX_ENDPOINT_COUNT 
- Add tt_NODE_ID_INVALID and tt_NODE_ID_BROADCAST
- Add endpoint topic_id for pub/sub topic routing
- Rename endpoint-related parameters and embedded endpoint fields
- Add HAL-based endpoint lock support
- Protect endpoint add/remove/find and endpoint iteration paths
- Snapshot subscribers before callback dispatch to avoid holding locks while running user code
- Add endpoint unit tests and fix lint warning

**3. Test**

- Added tests/test_endpoint.c
- Updated tests/test_mock.h for endpoint lock mock coverage
- Updated tests/test_callresponse.c for renamed endpoint fields


**4. Issue**

- [SW-2053](https://linear.app/tsnlab/issue/SW-2053/tt-node-create-client-%EC%97%90%EC%84%9C-endpoint-%EB%A5%BC-%EC%B6%94%EA%B0%80%ED%95%A0-%EB%95%8C-tt-max-endpoint-count-%ED%99%95%EC%9D%B8)
- [SW-2022](https://linear.app/tsnlab/issue/SW-2022/tt-node-create-%EC%97%90%EC%84%9C-node-id-%EA%B0%80-0-%EC%9D%B4%EB%82%98-255-%EB%8A%94-%EB%B6%88%EA%B0%80%ED%95%98%EA%B8%B0-%EB%95%8C%EB%AC%B8%EC%97%90-define-%EC%9D%B4%EB%82%98-const-%EB%A1%9C-%EB%B3%80%EA%B2%BD)
- [SW-2019](https://linear.app/tsnlab/issue/SW-2019/tt-node-create-subscriber-%EC%97%90%EC%84%9C-endpoint-id-%EC%A4%91%EB%B3%B5-%EA%B2%80%EC%82%AC%ED%95%B4%EC%84%9C-%EC%98%A4%EB%A5%98-%EC%B2%98%EB%A6%AChttps://linear.app/tsnlab/issue/SW-2019/tt-node-create-subscriber-%EC%97%90%EC%84%9C-endpoint-id-%EC%A4%91%EB%B3%B5-%EA%B2%80%EC%82%AC%ED%95%B4%EC%84%9C-%EC%98%A4%EB%A5%98-%EC%B2%98%EB%A6%AC)