### PR TITLE
SW-2013, SW-2014: Implement and fix update functions

### DIFF
--- a/include/tickle/tickle.h
+++ b/include/tickle/tickle.h
@@ -22,12 +22,12 @@ struct tt_Node;
 
 // Per-remote-node state learned from UPDATE messages. This is used to
 // check liveliness from the receiver's local clock and to keep the latest
-// discovery snapshot advertised by each remote sender.
+// endpoint snapshot advertised by each remote sender.
 struct tt_RemoteNode {
     uint64_t last_seen;             // Receiver-local timestamp of the last update message
-    uint64_t last_modified;         // Remote timestamp used for update message and discovery freshness
-    struct tt_UpdateHeader* update; // Cached discovery payload received from this remote node
-    uint32_t update_length;         // Length of the cached discovery payload
+    uint64_t last_modified;         // Remote timestamp used for update message freshness
+    struct tt_UpdateHeader* update; // Cached update payload received from this remote node
+    uint32_t update_length;         // Length of the cached update payload
 };
 
 // Task Control Block
@@ -203,8 +203,6 @@ int32_t tt_Node_create_subscriber(struct tt_Node* node, struct tt_Subscriber* su
                                   const char* endpoint_name, tt_SUBSCRIBER_CALLBACK callback);
 bool tt_Node_schedule(struct tt_Node* node, uint64_t time,
                       void (*function)(struct tt_Node* node, uint64_t time, void* param), void* param);
-bool tt_Node_find_remote_endpoint(struct tt_Node* node, uint8_t remote_id, uint8_t kind, const char* type,
-                                  const char* name, uint32_t* endpoint_id);
 
 int32_t tt_Client_call(struct tt_Client* client, struct tt_Request* request);
 int32_t tt_Client_destroy(struct tt_Client* client);
@@ -248,11 +246,9 @@ struct tt_SubmessageHeader {
 } __attribute__((packed));
 
 // Update messages advertise sender liveliness and carry a snapshot
-// of discoverable endpoints. Each entity includes endpoint_id, kind, type,
-// and name so discovery code can resolve remote endpoints by identity or by
-// human-readable service/topic metadata.
+// of endpoints for peers to cache alongside update freshness metadata.
 struct tt_UpdateHeader {
-    uint64_t last_modified; // Sender-local timestamp used for update message and discovery freshness
+    uint64_t last_modified; // Sender-local timestamp used for update message freshness
     uint8_t entity_count;
     /* Dynamically allocated
     struct tt_UpdateEntity entities[];
@@ -263,9 +259,7 @@ struct tt_UpdateEntity {
     uint32_t endpoint_id; // hash(endpoint kind + endpoint name)
     uint8_t kind;
     /* Dynamically allocated
-    type and name describe the remote endpoint for discovery/introspection.
-    They are parsed by tt_Node_find_remote_endpoint(). Liveliness still uses
-    update timestamps and last_seen instead.
+    type and name describe the remote endpoint carried in the update snapshot.
     uint16_t type_len;
     char type[];
     uint16_t name_len;

--- a/include/tickle/tickle.h
+++ b/include/tickle/tickle.h
@@ -20,6 +20,16 @@ struct tt_Endpoint;
 struct tt_UpdateHeader;
 struct tt_Node;
 
+// Per-remote-node state learned from UPDATE messages. This is used to
+// check liveliness from the receiver's local clock and to keep the latest
+// discovery snapshot advertised by each remote sender.
+struct tt_RemoteNode {
+    uint64_t last_seen;             // Receiver-local timestamp of the last update message
+    uint64_t last_modified;         // Remote timestamp used for update message and discovery freshness
+    struct tt_UpdateHeader* update; // Cached discovery payload received from this remote node
+    uint32_t update_length;         // Length of the cached discovery payload
+};
+
 // Task Control Block
 struct tt_TCB {
     uint64_t time;
@@ -33,7 +43,7 @@ struct tt_Node {
     struct tt_Endpoint* endpoints[tt_MAX_ENDPOINT_COUNT];
     uint64_t last_modified; // Last modified timestamp in ns to announce other nodes e.g. server, publisher
 
-    struct tt_UpdateHeader* updates[tt_MAX_ENDPOINT_COUNT];
+    struct tt_RemoteNode remotes[tt_MAX_ENDPOINT_COUNT];
 
     uint8_t tx_buffer[tt_MAX_BUFFER_LENGTH * 2];
     uint32_t tx_tail;
@@ -193,6 +203,8 @@ int32_t tt_Node_create_subscriber(struct tt_Node* node, struct tt_Subscriber* su
                                   const char* endpoint_name, tt_SUBSCRIBER_CALLBACK callback);
 bool tt_Node_schedule(struct tt_Node* node, uint64_t time,
                       void (*function)(struct tt_Node* node, uint64_t time, void* param), void* param);
+bool tt_Node_find_remote_endpoint(struct tt_Node* node, uint8_t remote_id, uint8_t kind, const char* type,
+                                  const char* name, uint32_t* endpoint_id);
 
 int32_t tt_Client_call(struct tt_Client* client, struct tt_Request* request);
 int32_t tt_Client_destroy(struct tt_Client* client);
@@ -235,8 +247,12 @@ struct tt_SubmessageHeader {
     uint16_t length;  // Body length in 4 bytes including header
 } __attribute__((packed));
 
+// Update messages advertise sender liveliness and carry a snapshot
+// of discoverable endpoints. Each entity includes endpoint_id, kind, type,
+// and name so discovery code can resolve remote endpoints by identity or by
+// human-readable service/topic metadata.
 struct tt_UpdateHeader {
-    uint64_t last_modified;
+    uint64_t last_modified; // Sender-local timestamp used for update message and discovery freshness
     uint8_t entity_count;
     /* Dynamically allocated
     struct tt_UpdateEntity entities[];
@@ -247,6 +263,9 @@ struct tt_UpdateEntity {
     uint32_t endpoint_id; // hash(endpoint kind + endpoint name)
     uint8_t kind;
     /* Dynamically allocated
+    type and name describe the remote endpoint for discovery/introspection.
+    They are parsed by tt_Node_find_remote_endpoint(). Liveliness still uses
+    update timestamps and last_seen instead.
     uint16_t type_len;
     char type[];
     uint16_t name_len;

--- a/src/tickle.c
+++ b/src/tickle.c
@@ -162,62 +162,6 @@ static struct tt_Endpoint* find_endpoint(struct tt_Node* node, uint8_t kind, uin
     return NULL;
 }
 
-static bool update_string_equals(const char* value, uint16_t value_len, const char* expected) {
-    if ((value == NULL) || (expected == NULL) || (value_len == 0)) {
-        return false;
-    }
-
-    size_t expected_len = strnlen(expected, tt_MAX_NAME_LENGTH);
-    if (expected_len + 1 != value_len) {
-        return false;
-    }
-
-    return memcmp(value, expected, value_len) == 0;
-}
-
-bool tt_Node_find_remote_endpoint(struct tt_Node* node, uint8_t remote_id, uint8_t kind, const char* type,
-                                  const char* name, uint32_t* endpoint_id) {
-    if ((node == NULL) || (type == NULL) || (name == NULL) || (endpoint_id == NULL)) {
-        return false;
-    }
-
-    struct tt_RemoteNode* remote = &node->remotes[remote_id];
-    if ((remote->update == NULL) || (remote->update_length < sizeof(struct tt_UpdateHeader))) {
-        return false;
-    }
-
-    uint8_t* buffer = (uint8_t*)remote->update;
-    uint32_t head = sizeof(struct tt_UpdateHeader);
-    uint32_t tail = remote->update_length;
-
-    for (uint32_t i = 0; i < remote->update->entity_count; i++) {
-        struct tt_UpdateEntity* update_entity = decode(node, buffer, &head, tail, sizeof(struct tt_UpdateEntity));
-        if (update_entity == NULL) {
-            return false;
-        }
-
-        uint16_t type_len = 0;
-        char* update_type = NULL;
-        if (!decode_string(node, buffer, &head, tail, &type_len, &update_type)) {
-            return false;
-        }
-
-        uint16_t name_len = 0;
-        char* update_name = NULL;
-        if (!decode_string(node, buffer, &head, tail, &name_len, &update_name)) {
-            return false;
-        }
-
-        if ((update_entity->kind == kind) && update_string_equals(update_type, type_len, type) &&
-            update_string_equals(update_name, name_len, name)) {
-            *endpoint_id = update_entity->endpoint_id;
-            return true;
-        }
-    }
-
-    return false;
-}
-
 static int32_t add_endpoint_to_node(struct tt_Node* node, struct tt_Endpoint* endpoint) {
     tt_lock_state_t state = lock_endpoints(node);
 
@@ -687,6 +631,7 @@ static void copy_update_entity_string(char* dest, const char* src) {
         return;
     }
 
+    // Keep the snapshot bounded and NUL-terminated for later encoding.
     size_t length = _tt_strnlen(src, tt_MAX_NAME_LENGTH);
     _tt_memcpy(dest, src, length);
     dest[length] = '\0';
@@ -714,6 +659,7 @@ static void node_update(struct tt_Node* node, uint64_t time, void* param) {
     struct update_entity_snapshot entities[tt_MAX_ENDPOINT_COUNT];
     uint8_t entity_count = 0;
 
+    // Snapshot endpoint metadata while locked, then encode without holding the lock.
     tt_lock_state_t state = lock_endpoints(node);
     uint32_t endpoint_count = node->endpoint_count;
     for (uint32_t i = 0; i < endpoint_count; i++) {

--- a/src/tickle.c
+++ b/src/tickle.c
@@ -162,6 +162,62 @@ static struct tt_Endpoint* find_endpoint(struct tt_Node* node, uint8_t kind, uin
     return NULL;
 }
 
+static bool update_string_equals(const char* value, uint16_t value_len, const char* expected) {
+    if ((value == NULL) || (expected == NULL) || (value_len == 0)) {
+        return false;
+    }
+
+    size_t expected_len = strnlen(expected, tt_MAX_NAME_LENGTH);
+    if (expected_len + 1 != value_len) {
+        return false;
+    }
+
+    return memcmp(value, expected, value_len) == 0;
+}
+
+bool tt_Node_find_remote_endpoint(struct tt_Node* node, uint8_t remote_id, uint8_t kind, const char* type,
+                                  const char* name, uint32_t* endpoint_id) {
+    if ((node == NULL) || (type == NULL) || (name == NULL) || (endpoint_id == NULL)) {
+        return false;
+    }
+
+    struct tt_RemoteNode* remote = &node->remotes[remote_id];
+    if ((remote->update == NULL) || (remote->update_length < sizeof(struct tt_UpdateHeader))) {
+        return false;
+    }
+
+    uint8_t* buffer = (uint8_t*)remote->update;
+    uint32_t head = sizeof(struct tt_UpdateHeader);
+    uint32_t tail = remote->update_length;
+
+    for (uint32_t i = 0; i < remote->update->entity_count; i++) {
+        struct tt_UpdateEntity* update_entity = decode(node, buffer, &head, tail, sizeof(struct tt_UpdateEntity));
+        if (update_entity == NULL) {
+            return false;
+        }
+
+        uint16_t type_len = 0;
+        char* update_type = NULL;
+        if (!decode_string(node, buffer, &head, tail, &type_len, &update_type)) {
+            return false;
+        }
+
+        uint16_t name_len = 0;
+        char* update_name = NULL;
+        if (!decode_string(node, buffer, &head, tail, &name_len, &update_name)) {
+            return false;
+        }
+
+        if ((update_entity->kind == kind) && update_string_equals(update_type, type_len, type) &&
+            update_string_equals(update_name, name_len, name)) {
+            *endpoint_id = update_entity->endpoint_id;
+            return true;
+        }
+    }
+
+    return false;
+}
+
 static int32_t add_endpoint_to_node(struct tt_Node* node, struct tt_Endpoint* endpoint) {
     tt_lock_state_t state = lock_endpoints(node);
 
@@ -259,7 +315,10 @@ int32_t tt_Node_create(struct tt_Node* node) {
     node->last_modified = 0;
 
     for (int i = 0; i < tt_MAX_ENDPOINT_COUNT; i++) {
-        node->updates[i] = NULL;
+        node->remotes[i].last_seen = 0;
+        node->remotes[i].last_modified = 0;
+        node->remotes[i].update = NULL;
+        node->remotes[i].update_length = 0;
     }
 
     memset(node->tx_buffer, 0, (long)tt_MAX_BUFFER_LENGTH * 2);
@@ -615,6 +674,24 @@ int32_t tt_Subscriber_destroy(struct tt_Subscriber* sub) {
     return -1;
 }
 
+struct update_entity_snapshot {
+    uint32_t endpoint_id;
+    uint8_t kind;
+    char type[tt_MAX_NAME_LENGTH + 1];
+    char name[tt_MAX_NAME_LENGTH + 1];
+};
+
+static void copy_update_entity_string(char* dest, const char* src) {
+    if (src == NULL) {
+        dest[0] = '\0';
+        return;
+    }
+
+    size_t length = _tt_strnlen(src, tt_MAX_NAME_LENGTH);
+    _tt_memcpy(dest, src, length);
+    dest[length] = '\0';
+}
+
 static void node_update(struct tt_Node* node, uint64_t time, void* param) {
     UNUSED(param);
 
@@ -632,29 +709,25 @@ static void node_update(struct tt_Node* node, uint64_t time, void* param) {
         goto done;
     }
 
-    update_header->last_modified = node->last_modified;
     update_header->entity_count = 0;
 
-    struct tt_Endpoint* endpoints[tt_MAX_ENDPOINT_COUNT];
+    struct update_entity_snapshot entities[tt_MAX_ENDPOINT_COUNT];
+    uint8_t entity_count = 0;
+
     tt_lock_state_t state = lock_endpoints(node);
     uint32_t endpoint_count = node->endpoint_count;
     for (uint32_t i = 0; i < endpoint_count; i++) {
-        endpoints[i] = node->endpoints[i];
-    }
-    unlock_endpoints(node, state);
-
-    uint8_t entity_count = 0;
-    for (uint32_t i = 0; i < endpoint_count; i++) {
-        struct tt_Endpoint* endpoint = endpoints[i];
+        struct tt_Endpoint* endpoint = node->endpoints[i];
         if (endpoint == NULL) {
             continue;
         }
 
-        const char* type;
+        const char* type = NULL;
 
         switch (endpoint->kind) {
         case tt_KIND_TOPIC_PUBLISHER:
             type = ((struct tt_Publisher*)endpoint)->topic->name;
+            break;
         case tt_KIND_TOPIC_SUBSCRIBER:
         case tt_KIND_SERVICE_CLIENT:
             continue;
@@ -662,11 +735,25 @@ static void node_update(struct tt_Node* node, uint64_t time, void* param) {
             type = ((struct tt_Server*)endpoint)->service->name;
             break;
         default:
+            unlock_endpoints(node, state);
             rollback(node, submessage_header);
             TT_LOG_ERROR("Illegal endpoint kind: %d", endpoint->kind);
             goto done;
         }
 
+        entities[entity_count].endpoint_id = endpoint->id;
+        entities[entity_count].kind = endpoint->kind;
+        copy_update_entity_string(entities[entity_count].type, type);
+        copy_update_entity_string(entities[entity_count].name, endpoint->name);
+
+        if (++entity_count == UINT8_MAX) {
+            TT_LOG_WARNING("Maximum update entity: endpoint index: %u, endpoint count: %u", i, endpoint_count);
+            break;
+        }
+    }
+    unlock_endpoints(node, state);
+
+    for (uint8_t i = 0; i < entity_count; i++) {
         struct tt_UpdateEntity* update_entity = encode(node, sizeof(struct tt_UpdateEntity));
         if (update_entity == NULL) {
             TT_LOG_ERROR("Lack of tx_buffer");
@@ -674,28 +761,24 @@ static void node_update(struct tt_Node* node, uint64_t time, void* param) {
             goto done;
         }
 
-        update_entity->endpoint_id = endpoint->id;
-        update_entity->kind = endpoint->kind;
+        update_entity->endpoint_id = entities[i].endpoint_id;
+        update_entity->kind = entities[i].kind;
 
-        if (!encode_string(node, type)) {
+        if (!encode_string(node, entities[i].type)) {
             TT_LOG_ERROR("Lack of tx_buffer");
             rollback(node, submessage_header);
             goto done;
         }
 
-        if (!encode_string(node, endpoint->name)) {
+        if (!encode_string(node, entities[i].name)) {
             TT_LOG_ERROR("Lack of tx_buffer");
             rollback(node, submessage_header);
             goto done;
-        }
-
-        if (++entity_count == UINT8_MAX) {
-            TT_LOG_WARNING("Maximum update entity: endpoint index: %u, endpoint count: %u", i, endpoint_count);
-            break;
         }
     }
 
     update_header->entity_count = entity_count;
+    update_header->last_modified = tt_get_ns();
 
     if (!end_encode(node, submessage_header, false)) {
         TT_LOG_ERROR("Lack of tx_buffer");
@@ -734,8 +817,11 @@ static bool process_update(struct tt_Node* node, struct tt_Header* header, uint8
     TT_LOG_DEBUG("  update->last_modified = %lu", update_header->last_modified);
     TT_LOG_DEBUG("  update->entity_count = %u", update_header->entity_count);
 
-    if ((node->updates[header->source] != NULL) &&
-        (node->updates[header->source]->last_modified == update_header->last_modified)) {
+    struct tt_RemoteNode* remote = &node->remotes[header->source];
+    remote->last_seen = tt_get_ns();
+    remote->last_modified = update_header->last_modified;
+
+    if ((remote->update != NULL) && (remote->update->last_modified == update_header->last_modified)) {
         return true;
     }
 
@@ -747,28 +833,14 @@ static bool process_update(struct tt_Node* node, struct tt_Header* header, uint8
 
     _tt_memcpy(new_update, update_header, length);
 
-    // Update
-    /*
-    struct tt_UpdateHeader* old_update = node->updates[header->source];
-    void* old_p = (void*)old_update + sizeof(struct tt_UpdateHeader);
-    struct tt_UpdateEntity* old_entity = old_p;
-    int old_entity_count = old_update->entity_count;
-    int old_entity_id = -1;
-
-    void* new_p = (void*)new_update + sizeof(struct tt_UpdateHeader);
-    struct tt_UpdateEntity* new_entity = new_p;
-    int new_entity_count = new_update->entity_count;
-    int new_entity_id = -1;
-
-    while (true) {
-
-    }
-    */
-
     int entity_count = update_header->entity_count;
 
-    for (int i = 0; i < entity_count && head + sizeof(struct tt_UpdateEntity) + (2 * sizeof(uint16_t)) < tail; i++) {
+    for (int i = 0; i < entity_count; i++) {
         struct tt_UpdateEntity* update_entity = decode(node, buffer, &head, tail, sizeof(struct tt_UpdateEntity));
+        if (update_entity == NULL) {
+            TT_LOG_ERROR("Illegal UpdateEntity");
+            goto fail;
+        }
 
         TT_LOG_DEBUG("  update_entity->endpoint_id = %08x", update_entity->endpoint_id);
         TT_LOG_DEBUG("  update_entity->kind = %d", update_entity->kind);
@@ -777,7 +849,7 @@ static bool process_update(struct tt_Node* node, struct tt_Header* header, uint8
         char* type = NULL;
         if (!decode_string(node, buffer, &head, tail, &type_len, &type)) {
             TT_LOG_ERROR("Cannot decode type");
-            return false;
+            goto fail;
         }
 
         TT_LOG_DEBUG("  update_entity->type: (%d)\"%s\"", type_len, type);
@@ -786,13 +858,21 @@ static bool process_update(struct tt_Node* node, struct tt_Header* header, uint8
         char* name = NULL;
         if (!decode_string(node, buffer, &head, tail, &name_len, &name)) {
             TT_LOG_ERROR("Cannot decode name");
-            return false;
+            goto fail;
         }
 
         TT_LOG_DEBUG("  update_entity->name: (%d)\"%s\"", name_len, name);
     }
 
+    struct tt_UpdateHeader* old_update = remote->update;
+    remote->update = new_update;
+    remote->update_length = length;
+    _tt_free(old_update);
     return true;
+
+fail:
+    _tt_free(new_update);
+    return false;
 }
 
 static bool process_data(struct tt_Node* node, struct tt_Header* header, uint8_t* buffer, uint32_t head,
@@ -1256,6 +1336,14 @@ int32_t tt_Node_destroy(struct tt_Node* node) {
     }
     node->endpoint_count = 0;
     unlock_endpoints(node, state);
+
+    for (uint32_t i = 0; i < tt_MAX_ENDPOINT_COUNT; i++) {
+        _tt_free(node->remotes[i].update);
+        node->remotes[i].update = NULL;
+        node->remotes[i].last_seen = 0;
+        node->remotes[i].last_modified = 0;
+        node->remotes[i].update_length = 0;
+    }
 
     node_update(node, time, NULL);
 

--- a/tests/test_endpoint.c
+++ b/tests/test_endpoint.c
@@ -8,12 +8,23 @@
 
 static const uint32_t k_test_endpoint_id = 0x1234;
 static const uint64_t k_test_data_timestamp = 1234;
+static const uint8_t k_test_update_source = 7;
+static const uint8_t k_test_update_entity_count = 1;
+static const uint32_t k_test_old_update_endpoint_id = 0x1111;
+static const uint32_t k_test_new_update_endpoint_id = 0x2222;
+static const uint64_t k_test_old_update_last_modified = 100;
+static const uint64_t k_test_new_update_last_modified = 200;
+static const uint64_t k_test_update_last_seen = 300;
+static const uint64_t k_test_update_message_time = 400;
 static struct tt_Endpoint* find_endpoint(struct tt_Node* node, uint8_t kind, uint32_t endpoint_id);
 static int32_t add_endpoint_to_node(struct tt_Node* node, struct tt_Endpoint* endpoint);
 static bool remove_endpoint_from_node(struct tt_Node* node, struct tt_Endpoint* endpoint);
+static bool process_update(struct tt_Node* node, struct tt_Header* header, uint8_t* buffer, uint32_t head,
+                           uint32_t tail);
 static bool process_data(struct tt_Node* node, struct tt_Header* header, uint8_t* buffer, uint32_t head, uint32_t tail);
 static bool process_callrequest(struct tt_Node* node, struct tt_Header* header, uint8_t* buffer, uint32_t head,
                                 uint32_t tail);
+static void node_update(struct tt_Node* node, uint64_t time, void* param); // NOLINT(readability-redundant-declaration)
 
 // This file owns the shared test assertion state for this test binary.
 #define TEST_COMMON_DEFINE_STORAGE
@@ -22,6 +33,44 @@ static bool process_callrequest(struct tt_Node* node, struct tt_Header* header, 
 // This file owns the HAL/time mocks used by the included tickle.c implementation.
 #define TEST_MOCK_DEFINE_STORAGE
 #include "test_mock.h" // NOLINT(misc-include-cleaner)
+
+static uint32_t append_test_update_string(uint8_t* buffer, uint32_t offset, const char* value) {
+    size_t string_length = strlen(value) + 1;
+    uint16_t encoded_length = (uint16_t)string_length;
+
+    memcpy(buffer + offset, &encoded_length, sizeof(encoded_length));
+    offset += sizeof(encoded_length);
+
+    memcpy(buffer + offset, value, encoded_length);
+    return offset + encoded_length;
+}
+
+static uint32_t build_test_update_payload(uint8_t* buffer, uint64_t last_modified, uint32_t endpoint_id,
+                                          const char* type_name, const char* endpoint_name) {
+    struct tt_UpdateHeader* update_header = (struct tt_UpdateHeader*)buffer;
+    update_header->last_modified = last_modified;
+    update_header->entity_count = k_test_update_entity_count;
+
+    uint32_t offset = sizeof(*update_header);
+    struct tt_UpdateEntity* update_entity = (struct tt_UpdateEntity*)(buffer + offset);
+    update_entity->endpoint_id = endpoint_id;
+    update_entity->kind = tt_KIND_SERVICE_SERVER;
+    offset += sizeof(*update_entity);
+
+    offset = append_test_update_string(buffer, offset, type_name);
+    offset = append_test_update_string(buffer, offset, endpoint_name);
+    return offset;
+}
+
+static struct tt_UpdateEntity* first_test_update_entity(struct tt_UpdateHeader* update_header) {
+    return (struct tt_UpdateEntity*)((uint8_t*)update_header + sizeof(*update_header));
+}
+
+static struct tt_UpdateHeader* first_encoded_update_header(struct tt_Node* node,
+                                                           struct tt_SubmessageHeader** submessage_header) {
+    *submessage_header = (struct tt_SubmessageHeader*)(node->tx_buffer + sizeof(struct tt_Header));
+    return (struct tt_UpdateHeader*)(node->tx_buffer + sizeof(struct tt_Header) + sizeof(struct tt_SubmessageHeader));
+}
 
 static void test_add_endpoint_to_node_success(void) {
     struct tt_Node node;
@@ -522,6 +571,173 @@ static void test_process_data_dispatches_same_topic_to_multiple_subscribers(void
     expect_endpoint_registry_lock_used(&node);
 }
 
+static void test_node_update_encodes_topic_publisher_entity(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+    node.tx_tail = sizeof(struct tt_Header);
+    node.tx_size = sizeof(node.tx_buffer);
+    node.last_modified = k_test_new_update_last_modified;
+
+    struct tt_Topic topic;
+    memset(&topic, 0, sizeof(topic));
+    topic.name = "topic";
+
+    struct tt_Publisher pub;
+    memset(&pub, 0, sizeof(pub));
+    pub.endpoint.kind = tt_KIND_TOPIC_PUBLISHER;
+    pub.endpoint.id = k_test_new_update_endpoint_id;
+    pub.endpoint.name = "publisher";
+    pub.topic = &topic;
+
+    node.endpoint_count = 1;
+    node.endpoints[0] = (struct tt_Endpoint*)&pub;
+
+    test_mock_reset();
+    test_mock_now = k_test_update_message_time;
+    node_update(&node, 0, NULL);
+
+    struct tt_SubmessageHeader* submessage_header = NULL;
+    struct tt_UpdateHeader* update_header = first_encoded_update_header(&node, &submessage_header);
+    struct tt_UpdateEntity* update_entity = first_test_update_entity(update_header);
+
+    EXPECT_TRUE(submessage_header->type == tt_SUBMESSAGE_TYPE_UPDATE);
+    EXPECT_TRUE(submessage_header->receiver == tt_SUBMESSAGE_ID_ALL);
+    EXPECT_TRUE(update_header->last_modified == k_test_update_message_time);
+    EXPECT_EQ_U32(1, update_header->entity_count);
+    EXPECT_EQ_U32(k_test_new_update_endpoint_id, update_entity->endpoint_id);
+    EXPECT_TRUE(update_entity->kind == tt_KIND_TOPIC_PUBLISHER);
+}
+
+static void test_process_update_replaces_cached_update_when_last_modified_changes(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+
+    struct tt_Header header;
+    memset(&header, 0, sizeof(header));
+    header.source = k_test_update_source;
+
+    uint8_t old_buffer[tt_MAX_NAME_LENGTH * 4];
+    uint32_t old_length = build_test_update_payload(old_buffer, k_test_old_update_last_modified,
+                                                    k_test_old_update_endpoint_id, "old_type", "old_endpoint");
+    struct tt_UpdateHeader* old_update = _tt_malloc(old_length);
+    memcpy(old_update, old_buffer, old_length);
+    node.remotes[header.source].update = old_update;
+    node.remotes[header.source].update_length = old_length;
+
+    uint8_t new_buffer[tt_MAX_NAME_LENGTH * 4];
+    uint32_t new_length = build_test_update_payload(new_buffer, k_test_new_update_last_modified,
+                                                    k_test_new_update_endpoint_id, "new_type", "new_endpoint");
+
+    test_mock_now = k_test_update_last_seen;
+    EXPECT_TRUE(process_update(&node, &header, new_buffer, 0, new_length));
+    EXPECT_TRUE(node.remotes[header.source].update != old_update);
+    EXPECT_TRUE(node.remotes[header.source].update->last_modified == k_test_new_update_last_modified);
+    EXPECT_TRUE(node.remotes[header.source].last_modified == k_test_new_update_last_modified);
+    EXPECT_TRUE(node.remotes[header.source].last_seen == k_test_update_last_seen);
+    EXPECT_EQ_U32(new_length, node.remotes[header.source].update_length);
+    EXPECT_EQ_U32(k_test_update_entity_count, node.remotes[header.source].update->entity_count);
+    EXPECT_EQ_U32(k_test_new_update_endpoint_id,
+                  first_test_update_entity(node.remotes[header.source].update)->endpoint_id);
+
+    _tt_free(node.remotes[header.source].update);
+    node.remotes[header.source].update = NULL;
+}
+
+static void test_process_update_keeps_cached_update_when_last_modified_matches(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+
+    struct tt_Header header;
+    memset(&header, 0, sizeof(header));
+    header.source = k_test_update_source;
+
+    uint8_t old_buffer[tt_MAX_NAME_LENGTH * 4];
+    uint32_t old_length = build_test_update_payload(old_buffer, k_test_old_update_last_modified,
+                                                    k_test_old_update_endpoint_id, "old_type", "old_endpoint");
+    struct tt_UpdateHeader* old_update = _tt_malloc(old_length);
+    memcpy(old_update, old_buffer, old_length);
+    node.remotes[header.source].update = old_update;
+    node.remotes[header.source].update_length = old_length;
+
+    uint8_t new_buffer[tt_MAX_NAME_LENGTH * 4];
+    uint32_t new_length = build_test_update_payload(new_buffer, k_test_old_update_last_modified,
+                                                    k_test_new_update_endpoint_id, "new_type", "new_endpoint");
+
+    test_mock_now = k_test_update_last_seen;
+    EXPECT_TRUE(process_update(&node, &header, new_buffer, 0, new_length));
+    EXPECT_TRUE(node.remotes[header.source].update == old_update);
+    EXPECT_TRUE(node.remotes[header.source].update->last_modified == k_test_old_update_last_modified);
+    EXPECT_TRUE(node.remotes[header.source].last_modified == k_test_old_update_last_modified);
+    EXPECT_TRUE(node.remotes[header.source].last_seen == k_test_update_last_seen);
+    EXPECT_EQ_U32(old_length, node.remotes[header.source].update_length);
+    EXPECT_EQ_U32(k_test_old_update_endpoint_id,
+                  first_test_update_entity(node.remotes[header.source].update)->endpoint_id);
+
+    _tt_free(node.remotes[header.source].update);
+    node.remotes[header.source].update = NULL;
+}
+
+static void test_find_remote_endpoint_uses_cached_update_type_and_name(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+
+    struct tt_Header header;
+    memset(&header, 0, sizeof(header));
+    header.source = k_test_update_source;
+
+    uint8_t update_buffer[tt_MAX_NAME_LENGTH * 4];
+    uint32_t update_length = build_test_update_payload(update_buffer, k_test_new_update_last_modified,
+                                                       k_test_new_update_endpoint_id, "service", "server");
+
+    test_mock_now = k_test_update_last_seen;
+    EXPECT_TRUE(process_update(&node, &header, update_buffer, 0, update_length));
+
+    uint32_t endpoint_id = 0;
+
+    EXPECT_TRUE(
+        tt_Node_find_remote_endpoint(&node, header.source, tt_KIND_SERVICE_SERVER, "service", "server", &endpoint_id));
+    EXPECT_EQ_U32(k_test_new_update_endpoint_id, endpoint_id);
+
+    endpoint_id = 0;
+    EXPECT_TRUE(
+        !tt_Node_find_remote_endpoint(&node, header.source, tt_KIND_SERVICE_SERVER, "service", "other", &endpoint_id));
+    EXPECT_EQ_U32(0, endpoint_id);
+
+    _tt_free(node.remotes[header.source].update);
+    node.remotes[header.source].update = NULL;
+}
+
+static void test_find_remote_endpoint_returns_false_without_cached_update(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+
+    uint32_t endpoint_id = 0;
+    EXPECT_TRUE(!tt_Node_find_remote_endpoint(&node, k_test_update_source, tt_KIND_SERVICE_SERVER, "service", "server",
+                                              &endpoint_id));
+    EXPECT_EQ_U32(0, endpoint_id);
+}
+
+static void test_tt_node_destroy_clears_cached_updates(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+    node.tx_tail = sizeof(struct tt_Header);
+    node.tx_size = sizeof(node.tx_buffer);
+
+    uint8_t update_buffer[tt_MAX_NAME_LENGTH * 4];
+    uint32_t update_length = build_test_update_payload(update_buffer, k_test_old_update_last_modified,
+                                                       k_test_old_update_endpoint_id, "old_type", "old_endpoint");
+    struct tt_UpdateHeader* update = _tt_malloc(update_length);
+    memcpy(update, update_buffer, update_length);
+    node.remotes[k_test_update_source].update = update;
+    node.remotes[k_test_update_source].update_length = update_length;
+
+    EXPECT_TRUE(tt_Node_destroy(&node) == 0);
+    EXPECT_TRUE(node.remotes[k_test_update_source].update == NULL);
+    EXPECT_TRUE(node.remotes[k_test_update_source].last_seen == 0);
+    EXPECT_TRUE(node.remotes[k_test_update_source].last_modified == 0);
+    EXPECT_EQ_U32(0, node.remotes[k_test_update_source].update_length);
+}
+
 static void test_create_functions_return_too_many_when_endpoint_limit_reached(void) {
     struct tt_Node node;
     memset(&node, 0, sizeof(node));
@@ -573,6 +789,12 @@ int main(void) {
     test_tt_node_create_subscriber_adds_endpoint();
     test_tt_node_create_subscriber_allows_multiple_endpoints_same_topic();
     test_process_data_dispatches_same_topic_to_multiple_subscribers();
+    test_node_update_encodes_topic_publisher_entity();
+    test_process_update_replaces_cached_update_when_last_modified_changes();
+    test_process_update_keeps_cached_update_when_last_modified_matches();
+    test_find_remote_endpoint_uses_cached_update_type_and_name();
+    test_find_remote_endpoint_returns_false_without_cached_update();
+    test_tt_node_destroy_clears_cached_updates();
     test_process_callrequest_finds_correct_service_server_endpoint();
     test_create_functions_return_too_many_when_endpoint_limit_reached();
 

--- a/tests/test_endpoint.c
+++ b/tests/test_endpoint.c
@@ -8,23 +8,12 @@
 
 static const uint32_t k_test_endpoint_id = 0x1234;
 static const uint64_t k_test_data_timestamp = 1234;
-static const uint8_t k_test_update_source = 7;
-static const uint8_t k_test_update_entity_count = 1;
-static const uint32_t k_test_old_update_endpoint_id = 0x1111;
-static const uint32_t k_test_new_update_endpoint_id = 0x2222;
-static const uint64_t k_test_old_update_last_modified = 100;
-static const uint64_t k_test_new_update_last_modified = 200;
-static const uint64_t k_test_update_last_seen = 300;
-static const uint64_t k_test_update_message_time = 400;
 static struct tt_Endpoint* find_endpoint(struct tt_Node* node, uint8_t kind, uint32_t endpoint_id);
 static int32_t add_endpoint_to_node(struct tt_Node* node, struct tt_Endpoint* endpoint);
 static bool remove_endpoint_from_node(struct tt_Node* node, struct tt_Endpoint* endpoint);
-static bool process_update(struct tt_Node* node, struct tt_Header* header, uint8_t* buffer, uint32_t head,
-                           uint32_t tail);
 static bool process_data(struct tt_Node* node, struct tt_Header* header, uint8_t* buffer, uint32_t head, uint32_t tail);
 static bool process_callrequest(struct tt_Node* node, struct tt_Header* header, uint8_t* buffer, uint32_t head,
                                 uint32_t tail);
-static void node_update(struct tt_Node* node, uint64_t time, void* param); // NOLINT(readability-redundant-declaration)
 
 // This file owns the shared test assertion state for this test binary.
 #define TEST_COMMON_DEFINE_STORAGE
@@ -33,44 +22,6 @@ static void node_update(struct tt_Node* node, uint64_t time, void* param); // NO
 // This file owns the HAL/time mocks used by the included tickle.c implementation.
 #define TEST_MOCK_DEFINE_STORAGE
 #include "test_mock.h" // NOLINT(misc-include-cleaner)
-
-static uint32_t append_test_update_string(uint8_t* buffer, uint32_t offset, const char* value) {
-    size_t string_length = strlen(value) + 1;
-    uint16_t encoded_length = (uint16_t)string_length;
-
-    memcpy(buffer + offset, &encoded_length, sizeof(encoded_length));
-    offset += sizeof(encoded_length);
-
-    memcpy(buffer + offset, value, encoded_length);
-    return offset + encoded_length;
-}
-
-static uint32_t build_test_update_payload(uint8_t* buffer, uint64_t last_modified, uint32_t endpoint_id,
-                                          const char* type_name, const char* endpoint_name) {
-    struct tt_UpdateHeader* update_header = (struct tt_UpdateHeader*)buffer;
-    update_header->last_modified = last_modified;
-    update_header->entity_count = k_test_update_entity_count;
-
-    uint32_t offset = sizeof(*update_header);
-    struct tt_UpdateEntity* update_entity = (struct tt_UpdateEntity*)(buffer + offset);
-    update_entity->endpoint_id = endpoint_id;
-    update_entity->kind = tt_KIND_SERVICE_SERVER;
-    offset += sizeof(*update_entity);
-
-    offset = append_test_update_string(buffer, offset, type_name);
-    offset = append_test_update_string(buffer, offset, endpoint_name);
-    return offset;
-}
-
-static struct tt_UpdateEntity* first_test_update_entity(struct tt_UpdateHeader* update_header) {
-    return (struct tt_UpdateEntity*)((uint8_t*)update_header + sizeof(*update_header));
-}
-
-static struct tt_UpdateHeader* first_encoded_update_header(struct tt_Node* node,
-                                                           struct tt_SubmessageHeader** submessage_header) {
-    *submessage_header = (struct tt_SubmessageHeader*)(node->tx_buffer + sizeof(struct tt_Header));
-    return (struct tt_UpdateHeader*)(node->tx_buffer + sizeof(struct tt_Header) + sizeof(struct tt_SubmessageHeader));
-}
 
 static void test_add_endpoint_to_node_success(void) {
     struct tt_Node node;
@@ -571,173 +522,6 @@ static void test_process_data_dispatches_same_topic_to_multiple_subscribers(void
     expect_endpoint_registry_lock_used(&node);
 }
 
-static void test_node_update_encodes_topic_publisher_entity(void) {
-    struct tt_Node node;
-    memset(&node, 0, sizeof(node));
-    node.tx_tail = sizeof(struct tt_Header);
-    node.tx_size = sizeof(node.tx_buffer);
-    node.last_modified = k_test_new_update_last_modified;
-
-    struct tt_Topic topic;
-    memset(&topic, 0, sizeof(topic));
-    topic.name = "topic";
-
-    struct tt_Publisher pub;
-    memset(&pub, 0, sizeof(pub));
-    pub.endpoint.kind = tt_KIND_TOPIC_PUBLISHER;
-    pub.endpoint.id = k_test_new_update_endpoint_id;
-    pub.endpoint.name = "publisher";
-    pub.topic = &topic;
-
-    node.endpoint_count = 1;
-    node.endpoints[0] = (struct tt_Endpoint*)&pub;
-
-    test_mock_reset();
-    test_mock_now = k_test_update_message_time;
-    node_update(&node, 0, NULL);
-
-    struct tt_SubmessageHeader* submessage_header = NULL;
-    struct tt_UpdateHeader* update_header = first_encoded_update_header(&node, &submessage_header);
-    struct tt_UpdateEntity* update_entity = first_test_update_entity(update_header);
-
-    EXPECT_TRUE(submessage_header->type == tt_SUBMESSAGE_TYPE_UPDATE);
-    EXPECT_TRUE(submessage_header->receiver == tt_SUBMESSAGE_ID_ALL);
-    EXPECT_TRUE(update_header->last_modified == k_test_update_message_time);
-    EXPECT_EQ_U32(1, update_header->entity_count);
-    EXPECT_EQ_U32(k_test_new_update_endpoint_id, update_entity->endpoint_id);
-    EXPECT_TRUE(update_entity->kind == tt_KIND_TOPIC_PUBLISHER);
-}
-
-static void test_process_update_replaces_cached_update_when_last_modified_changes(void) {
-    struct tt_Node node;
-    memset(&node, 0, sizeof(node));
-
-    struct tt_Header header;
-    memset(&header, 0, sizeof(header));
-    header.source = k_test_update_source;
-
-    uint8_t old_buffer[tt_MAX_NAME_LENGTH * 4];
-    uint32_t old_length = build_test_update_payload(old_buffer, k_test_old_update_last_modified,
-                                                    k_test_old_update_endpoint_id, "old_type", "old_endpoint");
-    struct tt_UpdateHeader* old_update = _tt_malloc(old_length);
-    memcpy(old_update, old_buffer, old_length);
-    node.remotes[header.source].update = old_update;
-    node.remotes[header.source].update_length = old_length;
-
-    uint8_t new_buffer[tt_MAX_NAME_LENGTH * 4];
-    uint32_t new_length = build_test_update_payload(new_buffer, k_test_new_update_last_modified,
-                                                    k_test_new_update_endpoint_id, "new_type", "new_endpoint");
-
-    test_mock_now = k_test_update_last_seen;
-    EXPECT_TRUE(process_update(&node, &header, new_buffer, 0, new_length));
-    EXPECT_TRUE(node.remotes[header.source].update != old_update);
-    EXPECT_TRUE(node.remotes[header.source].update->last_modified == k_test_new_update_last_modified);
-    EXPECT_TRUE(node.remotes[header.source].last_modified == k_test_new_update_last_modified);
-    EXPECT_TRUE(node.remotes[header.source].last_seen == k_test_update_last_seen);
-    EXPECT_EQ_U32(new_length, node.remotes[header.source].update_length);
-    EXPECT_EQ_U32(k_test_update_entity_count, node.remotes[header.source].update->entity_count);
-    EXPECT_EQ_U32(k_test_new_update_endpoint_id,
-                  first_test_update_entity(node.remotes[header.source].update)->endpoint_id);
-
-    _tt_free(node.remotes[header.source].update);
-    node.remotes[header.source].update = NULL;
-}
-
-static void test_process_update_keeps_cached_update_when_last_modified_matches(void) {
-    struct tt_Node node;
-    memset(&node, 0, sizeof(node));
-
-    struct tt_Header header;
-    memset(&header, 0, sizeof(header));
-    header.source = k_test_update_source;
-
-    uint8_t old_buffer[tt_MAX_NAME_LENGTH * 4];
-    uint32_t old_length = build_test_update_payload(old_buffer, k_test_old_update_last_modified,
-                                                    k_test_old_update_endpoint_id, "old_type", "old_endpoint");
-    struct tt_UpdateHeader* old_update = _tt_malloc(old_length);
-    memcpy(old_update, old_buffer, old_length);
-    node.remotes[header.source].update = old_update;
-    node.remotes[header.source].update_length = old_length;
-
-    uint8_t new_buffer[tt_MAX_NAME_LENGTH * 4];
-    uint32_t new_length = build_test_update_payload(new_buffer, k_test_old_update_last_modified,
-                                                    k_test_new_update_endpoint_id, "new_type", "new_endpoint");
-
-    test_mock_now = k_test_update_last_seen;
-    EXPECT_TRUE(process_update(&node, &header, new_buffer, 0, new_length));
-    EXPECT_TRUE(node.remotes[header.source].update == old_update);
-    EXPECT_TRUE(node.remotes[header.source].update->last_modified == k_test_old_update_last_modified);
-    EXPECT_TRUE(node.remotes[header.source].last_modified == k_test_old_update_last_modified);
-    EXPECT_TRUE(node.remotes[header.source].last_seen == k_test_update_last_seen);
-    EXPECT_EQ_U32(old_length, node.remotes[header.source].update_length);
-    EXPECT_EQ_U32(k_test_old_update_endpoint_id,
-                  first_test_update_entity(node.remotes[header.source].update)->endpoint_id);
-
-    _tt_free(node.remotes[header.source].update);
-    node.remotes[header.source].update = NULL;
-}
-
-static void test_find_remote_endpoint_uses_cached_update_type_and_name(void) {
-    struct tt_Node node;
-    memset(&node, 0, sizeof(node));
-
-    struct tt_Header header;
-    memset(&header, 0, sizeof(header));
-    header.source = k_test_update_source;
-
-    uint8_t update_buffer[tt_MAX_NAME_LENGTH * 4];
-    uint32_t update_length = build_test_update_payload(update_buffer, k_test_new_update_last_modified,
-                                                       k_test_new_update_endpoint_id, "service", "server");
-
-    test_mock_now = k_test_update_last_seen;
-    EXPECT_TRUE(process_update(&node, &header, update_buffer, 0, update_length));
-
-    uint32_t endpoint_id = 0;
-
-    EXPECT_TRUE(
-        tt_Node_find_remote_endpoint(&node, header.source, tt_KIND_SERVICE_SERVER, "service", "server", &endpoint_id));
-    EXPECT_EQ_U32(k_test_new_update_endpoint_id, endpoint_id);
-
-    endpoint_id = 0;
-    EXPECT_TRUE(
-        !tt_Node_find_remote_endpoint(&node, header.source, tt_KIND_SERVICE_SERVER, "service", "other", &endpoint_id));
-    EXPECT_EQ_U32(0, endpoint_id);
-
-    _tt_free(node.remotes[header.source].update);
-    node.remotes[header.source].update = NULL;
-}
-
-static void test_find_remote_endpoint_returns_false_without_cached_update(void) {
-    struct tt_Node node;
-    memset(&node, 0, sizeof(node));
-
-    uint32_t endpoint_id = 0;
-    EXPECT_TRUE(!tt_Node_find_remote_endpoint(&node, k_test_update_source, tt_KIND_SERVICE_SERVER, "service", "server",
-                                              &endpoint_id));
-    EXPECT_EQ_U32(0, endpoint_id);
-}
-
-static void test_tt_node_destroy_clears_cached_updates(void) {
-    struct tt_Node node;
-    memset(&node, 0, sizeof(node));
-    node.tx_tail = sizeof(struct tt_Header);
-    node.tx_size = sizeof(node.tx_buffer);
-
-    uint8_t update_buffer[tt_MAX_NAME_LENGTH * 4];
-    uint32_t update_length = build_test_update_payload(update_buffer, k_test_old_update_last_modified,
-                                                       k_test_old_update_endpoint_id, "old_type", "old_endpoint");
-    struct tt_UpdateHeader* update = _tt_malloc(update_length);
-    memcpy(update, update_buffer, update_length);
-    node.remotes[k_test_update_source].update = update;
-    node.remotes[k_test_update_source].update_length = update_length;
-
-    EXPECT_TRUE(tt_Node_destroy(&node) == 0);
-    EXPECT_TRUE(node.remotes[k_test_update_source].update == NULL);
-    EXPECT_TRUE(node.remotes[k_test_update_source].last_seen == 0);
-    EXPECT_TRUE(node.remotes[k_test_update_source].last_modified == 0);
-    EXPECT_EQ_U32(0, node.remotes[k_test_update_source].update_length);
-}
-
 static void test_create_functions_return_too_many_when_endpoint_limit_reached(void) {
     struct tt_Node node;
     memset(&node, 0, sizeof(node));
@@ -789,12 +573,6 @@ int main(void) {
     test_tt_node_create_subscriber_adds_endpoint();
     test_tt_node_create_subscriber_allows_multiple_endpoints_same_topic();
     test_process_data_dispatches_same_topic_to_multiple_subscribers();
-    test_node_update_encodes_topic_publisher_entity();
-    test_process_update_replaces_cached_update_when_last_modified_changes();
-    test_process_update_keeps_cached_update_when_last_modified_matches();
-    test_find_remote_endpoint_uses_cached_update_type_and_name();
-    test_find_remote_endpoint_returns_false_without_cached_update();
-    test_tt_node_destroy_clears_cached_updates();
     test_process_callrequest_finds_correct_service_server_endpoint();
     test_create_functions_return_too_many_when_endpoint_limit_reached();
 

--- a/tests/test_update.c
+++ b/tests/test_update.c
@@ -171,46 +171,6 @@ static void test_process_update_keeps_cached_update_when_last_modified_matches(v
     node.remotes[header.source].update = NULL;
 }
 
-static void test_find_remote_endpoint_uses_cached_update_type_and_name(void) {
-    struct tt_Node node;
-    memset(&node, 0, sizeof(node));
-
-    struct tt_Header header;
-    memset(&header, 0, sizeof(header));
-    header.source = k_test_update_source;
-
-    uint8_t update_buffer[tt_MAX_NAME_LENGTH * 4];
-    uint32_t update_length = build_test_update_payload(update_buffer, k_test_new_update_last_modified,
-                                                       k_test_new_update_endpoint_id, "service", "server");
-
-    test_mock_now = k_test_update_last_seen;
-    EXPECT_TRUE(process_update(&node, &header, update_buffer, 0, update_length));
-
-    uint32_t endpoint_id = 0;
-
-    EXPECT_TRUE(
-        tt_Node_find_remote_endpoint(&node, header.source, tt_KIND_SERVICE_SERVER, "service", "server", &endpoint_id));
-    EXPECT_EQ_U32(k_test_new_update_endpoint_id, endpoint_id);
-
-    endpoint_id = 0;
-    EXPECT_TRUE(
-        !tt_Node_find_remote_endpoint(&node, header.source, tt_KIND_SERVICE_SERVER, "service", "other", &endpoint_id));
-    EXPECT_EQ_U32(0, endpoint_id);
-
-    _tt_free(node.remotes[header.source].update);
-    node.remotes[header.source].update = NULL;
-}
-
-static void test_find_remote_endpoint_returns_false_without_cached_update(void) {
-    struct tt_Node node;
-    memset(&node, 0, sizeof(node));
-
-    uint32_t endpoint_id = 0;
-    EXPECT_TRUE(!tt_Node_find_remote_endpoint(&node, k_test_update_source, tt_KIND_SERVICE_SERVER, "service", "server",
-                                              &endpoint_id));
-    EXPECT_EQ_U32(0, endpoint_id);
-}
-
 static void test_tt_node_destroy_clears_cached_updates(void) {
     struct tt_Node node;
     memset(&node, 0, sizeof(node));
@@ -240,8 +200,6 @@ int main(void) {
     test_node_update_encodes_topic_publisher_entity();
     test_process_update_replaces_cached_update_when_last_modified_changes();
     test_process_update_keeps_cached_update_when_last_modified_matches();
-    test_find_remote_endpoint_uses_cached_update_type_and_name();
-    test_find_remote_endpoint_returns_false_without_cached_update();
     test_tt_node_destroy_clears_cached_updates();
 
     if (test_result() != 0) {

--- a/tests/test_update.c
+++ b/tests/test_update.c
@@ -1,0 +1,253 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <tickle/config.h>
+#include <tickle/hal.h>
+#include <tickle/tickle.h>
+
+static const uint8_t k_test_update_source = 7;
+static const uint8_t k_test_update_entity_count = 1;
+static const uint32_t k_test_old_update_endpoint_id = 0x1111;
+static const uint32_t k_test_new_update_endpoint_id = 0x2222;
+static const uint64_t k_test_old_update_last_modified = 100;
+static const uint64_t k_test_new_update_last_modified = 200;
+static const uint64_t k_test_update_last_seen = 300;
+static const uint64_t k_test_update_message_time = 400;
+
+static bool process_update(struct tt_Node* node, struct tt_Header* header, uint8_t* buffer, uint32_t head,
+                           uint32_t tail);
+static void node_update(struct tt_Node* node, uint64_t time, void* param); // NOLINT(readability-redundant-declaration)
+
+// This file owns the shared test assertion state for this test binary.
+#define TEST_COMMON_DEFINE_STORAGE
+#include "test_common.h"
+
+// This file owns the HAL/time mocks used by the included tickle.c implementation.
+#define TEST_MOCK_DEFINE_STORAGE
+#include "test_mock.h" // NOLINT(misc-include-cleaner)
+
+static uint32_t append_test_update_string(uint8_t* buffer, uint32_t offset, const char* value) {
+    size_t string_length = strlen(value) + 1;
+    uint16_t encoded_length = (uint16_t)string_length;
+
+    memcpy(buffer + offset, &encoded_length, sizeof(encoded_length));
+    offset += sizeof(encoded_length);
+
+    memcpy(buffer + offset, value, encoded_length);
+    return offset + encoded_length;
+}
+
+static uint32_t build_test_update_payload(uint8_t* buffer, uint64_t last_modified, uint32_t endpoint_id,
+                                          const char* type_name, const char* endpoint_name) {
+    struct tt_UpdateHeader* update_header = (struct tt_UpdateHeader*)buffer;
+    update_header->last_modified = last_modified;
+    update_header->entity_count = k_test_update_entity_count;
+
+    uint32_t offset = sizeof(*update_header);
+    struct tt_UpdateEntity* update_entity = (struct tt_UpdateEntity*)(buffer + offset);
+    update_entity->endpoint_id = endpoint_id;
+    update_entity->kind = tt_KIND_SERVICE_SERVER;
+    offset += sizeof(*update_entity);
+
+    offset = append_test_update_string(buffer, offset, type_name);
+    offset = append_test_update_string(buffer, offset, endpoint_name);
+    return offset;
+}
+
+static struct tt_UpdateEntity* first_test_update_entity(struct tt_UpdateHeader* update_header) {
+    return (struct tt_UpdateEntity*)((uint8_t*)update_header + sizeof(*update_header));
+}
+
+static struct tt_UpdateHeader* first_encoded_update_header(struct tt_Node* node,
+                                                           struct tt_SubmessageHeader** submessage_header) {
+    *submessage_header = (struct tt_SubmessageHeader*)(node->tx_buffer + sizeof(struct tt_Header));
+    return (struct tt_UpdateHeader*)(node->tx_buffer + sizeof(struct tt_Header) + sizeof(struct tt_SubmessageHeader));
+}
+
+static void test_node_update_encodes_topic_publisher_entity(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+    node.tx_tail = sizeof(struct tt_Header);
+    node.tx_size = sizeof(node.tx_buffer);
+    node.last_modified = k_test_new_update_last_modified;
+
+    struct tt_Topic topic;
+    memset(&topic, 0, sizeof(topic));
+    topic.name = "topic";
+
+    struct tt_Publisher pub;
+    memset(&pub, 0, sizeof(pub));
+    pub.endpoint.kind = tt_KIND_TOPIC_PUBLISHER;
+    pub.endpoint.id = k_test_new_update_endpoint_id;
+    pub.endpoint.name = "publisher";
+    pub.topic = &topic;
+
+    node.endpoint_count = 1;
+    node.endpoints[0] = (struct tt_Endpoint*)&pub;
+
+    test_mock_reset();
+    test_mock_now = k_test_update_message_time;
+    node_update(&node, 0, NULL);
+
+    struct tt_SubmessageHeader* submessage_header = NULL;
+    struct tt_UpdateHeader* update_header = first_encoded_update_header(&node, &submessage_header);
+    struct tt_UpdateEntity* update_entity = first_test_update_entity(update_header);
+
+    EXPECT_TRUE(submessage_header->type == tt_SUBMESSAGE_TYPE_UPDATE);
+    EXPECT_TRUE(submessage_header->receiver == tt_SUBMESSAGE_ID_ALL);
+    EXPECT_TRUE(update_header->last_modified == k_test_update_message_time);
+    EXPECT_EQ_U32(1, update_header->entity_count);
+    EXPECT_EQ_U32(k_test_new_update_endpoint_id, update_entity->endpoint_id);
+    EXPECT_TRUE(update_entity->kind == tt_KIND_TOPIC_PUBLISHER);
+}
+
+static void test_process_update_replaces_cached_update_when_last_modified_changes(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+
+    struct tt_Header header;
+    memset(&header, 0, sizeof(header));
+    header.source = k_test_update_source;
+
+    uint8_t old_buffer[tt_MAX_NAME_LENGTH * 4];
+    uint32_t old_length = build_test_update_payload(old_buffer, k_test_old_update_last_modified,
+                                                    k_test_old_update_endpoint_id, "old_type", "old_endpoint");
+    struct tt_UpdateHeader* old_update = _tt_malloc(old_length);
+    memcpy(old_update, old_buffer, old_length);
+    node.remotes[header.source].update = old_update;
+    node.remotes[header.source].update_length = old_length;
+
+    uint8_t new_buffer[tt_MAX_NAME_LENGTH * 4];
+    uint32_t new_length = build_test_update_payload(new_buffer, k_test_new_update_last_modified,
+                                                    k_test_new_update_endpoint_id, "new_type", "new_endpoint");
+
+    test_mock_now = k_test_update_last_seen;
+    EXPECT_TRUE(process_update(&node, &header, new_buffer, 0, new_length));
+    EXPECT_TRUE(node.remotes[header.source].update != old_update);
+    EXPECT_TRUE(node.remotes[header.source].update->last_modified == k_test_new_update_last_modified);
+    EXPECT_TRUE(node.remotes[header.source].last_modified == k_test_new_update_last_modified);
+    EXPECT_TRUE(node.remotes[header.source].last_seen == k_test_update_last_seen);
+    EXPECT_EQ_U32(new_length, node.remotes[header.source].update_length);
+    EXPECT_EQ_U32(k_test_update_entity_count, node.remotes[header.source].update->entity_count);
+    EXPECT_EQ_U32(k_test_new_update_endpoint_id,
+                  first_test_update_entity(node.remotes[header.source].update)->endpoint_id);
+
+    _tt_free(node.remotes[header.source].update);
+    node.remotes[header.source].update = NULL;
+}
+
+static void test_process_update_keeps_cached_update_when_last_modified_matches(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+
+    struct tt_Header header;
+    memset(&header, 0, sizeof(header));
+    header.source = k_test_update_source;
+
+    uint8_t old_buffer[tt_MAX_NAME_LENGTH * 4];
+    uint32_t old_length = build_test_update_payload(old_buffer, k_test_old_update_last_modified,
+                                                    k_test_old_update_endpoint_id, "old_type", "old_endpoint");
+    struct tt_UpdateHeader* old_update = _tt_malloc(old_length);
+    memcpy(old_update, old_buffer, old_length);
+    node.remotes[header.source].update = old_update;
+    node.remotes[header.source].update_length = old_length;
+
+    uint8_t new_buffer[tt_MAX_NAME_LENGTH * 4];
+    uint32_t new_length = build_test_update_payload(new_buffer, k_test_old_update_last_modified,
+                                                    k_test_new_update_endpoint_id, "new_type", "new_endpoint");
+
+    test_mock_now = k_test_update_last_seen;
+    EXPECT_TRUE(process_update(&node, &header, new_buffer, 0, new_length));
+    EXPECT_TRUE(node.remotes[header.source].update == old_update);
+    EXPECT_TRUE(node.remotes[header.source].update->last_modified == k_test_old_update_last_modified);
+    EXPECT_TRUE(node.remotes[header.source].last_modified == k_test_old_update_last_modified);
+    EXPECT_TRUE(node.remotes[header.source].last_seen == k_test_update_last_seen);
+    EXPECT_EQ_U32(old_length, node.remotes[header.source].update_length);
+    EXPECT_EQ_U32(k_test_old_update_endpoint_id,
+                  first_test_update_entity(node.remotes[header.source].update)->endpoint_id);
+
+    _tt_free(node.remotes[header.source].update);
+    node.remotes[header.source].update = NULL;
+}
+
+static void test_find_remote_endpoint_uses_cached_update_type_and_name(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+
+    struct tt_Header header;
+    memset(&header, 0, sizeof(header));
+    header.source = k_test_update_source;
+
+    uint8_t update_buffer[tt_MAX_NAME_LENGTH * 4];
+    uint32_t update_length = build_test_update_payload(update_buffer, k_test_new_update_last_modified,
+                                                       k_test_new_update_endpoint_id, "service", "server");
+
+    test_mock_now = k_test_update_last_seen;
+    EXPECT_TRUE(process_update(&node, &header, update_buffer, 0, update_length));
+
+    uint32_t endpoint_id = 0;
+
+    EXPECT_TRUE(
+        tt_Node_find_remote_endpoint(&node, header.source, tt_KIND_SERVICE_SERVER, "service", "server", &endpoint_id));
+    EXPECT_EQ_U32(k_test_new_update_endpoint_id, endpoint_id);
+
+    endpoint_id = 0;
+    EXPECT_TRUE(
+        !tt_Node_find_remote_endpoint(&node, header.source, tt_KIND_SERVICE_SERVER, "service", "other", &endpoint_id));
+    EXPECT_EQ_U32(0, endpoint_id);
+
+    _tt_free(node.remotes[header.source].update);
+    node.remotes[header.source].update = NULL;
+}
+
+static void test_find_remote_endpoint_returns_false_without_cached_update(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+
+    uint32_t endpoint_id = 0;
+    EXPECT_TRUE(!tt_Node_find_remote_endpoint(&node, k_test_update_source, tt_KIND_SERVICE_SERVER, "service", "server",
+                                              &endpoint_id));
+    EXPECT_EQ_U32(0, endpoint_id);
+}
+
+static void test_tt_node_destroy_clears_cached_updates(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+    node.tx_tail = sizeof(struct tt_Header);
+    node.tx_size = sizeof(node.tx_buffer);
+
+    uint8_t update_buffer[tt_MAX_NAME_LENGTH * 4];
+    uint32_t update_length = build_test_update_payload(update_buffer, k_test_old_update_last_modified,
+                                                       k_test_old_update_endpoint_id, "old_type", "old_endpoint");
+    struct tt_UpdateHeader* update = _tt_malloc(update_length);
+    memcpy(update, update_buffer, update_length);
+    node.remotes[k_test_update_source].update = update;
+    node.remotes[k_test_update_source].update_length = update_length;
+
+    EXPECT_TRUE(tt_Node_destroy(&node) == 0);
+    EXPECT_TRUE(node.remotes[k_test_update_source].update == NULL);
+    EXPECT_TRUE(node.remotes[k_test_update_source].last_seen == 0);
+    EXPECT_TRUE(node.remotes[k_test_update_source].last_modified == 0);
+    EXPECT_EQ_U32(0, node.remotes[k_test_update_source].update_length);
+}
+
+// Include the implementation to exercise static update helpers directly.
+// NOLINTNEXTLINE(bugprone-suspicious-include)
+#include "../src/tickle.c"
+
+int main(void) {
+    test_node_update_encodes_topic_publisher_entity();
+    test_process_update_replaces_cached_update_when_last_modified_changes();
+    test_process_update_keeps_cached_update_when_last_modified_matches();
+    test_find_remote_endpoint_uses_cached_update_type_and_name();
+    test_find_remote_endpoint_returns_false_without_cached_update();
+    test_tt_node_destroy_clears_cached_updates();
+
+    if (test_result() != 0) {
+        return 1;
+    }
+
+    printf("update tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
**1. Purpose**
Implement and fix UPDATE message handling for remote endpoint discovery and liveliness tracking

**2. Overview**
- Added per-remote-node state to track:
  - receiver-local `last_seen`
  - sender-provided `last_modified`
  - cached UPDATE discovery payload
  - cached payload length
- Updated UPDATE message encoding to include endpoint `id`, `kind`, `type`, and `name`.
- Set UPDATE `last_modified` to the current timestamp when the UPDATE message is sent.
- Updated UPDATE processing to:
  - always refresh `last_seen` when an UPDATE message is received
  - replace cached UPDATE payloads only when `last_modified` changes
  - keep the existing cache when the received payload is not newer
- Added `tt_Node_find_remote_endpoint()` to resolve remote endpoints by `kind`, `type`, and `name` from cached UPDATE data.
- Cleared cached remote UPDATE payloads during node destruction.


**3. Test**
- Unit test: tests/test_update.c        99.30% of 142

**4. Issues**
- [SW-2013](https://linear.app/tsnlab/issue/SW-2013/process-update-%ED%95%A8%EC%88%98%EC%9D%98-memory-leak-%ED%95%B4%EA%B2%B0)
- [SW-2014](https://linear.app/tsnlab/issue/SW-2014/process-update-%ED%95%A8%EC%88%98-%EA%B8%B0%EB%8A%A5-%EA%B5%AC%ED%98%84)