### PR TITLE
SW-2019: Remove topic id from endpoint - revert

### DIFF
--- a/include/tickle/tickle.h
+++ b/include/tickle/tickle.h
@@ -51,8 +51,7 @@ struct tt_Node {
 
 struct tt_Endpoint {
     uint8_t kind;
-    uint32_t id;       // hash(endpoint kind + endpoint name)
-    uint32_t topic_id; // shared topic routing id for publisher/subscriber fan-out
+    uint32_t id; // hash(topic/service name + endpoint name)
     const char* name;
 };
 
@@ -244,7 +243,7 @@ struct tt_UpdateHeader {
 } __attribute__((packed));
 
 struct tt_UpdateEntity {
-    uint32_t endpoint_id; // hash(endpoint kind + endpoint name)
+    uint32_t endpoint_id; // hash(topic/service name + endpoint name)
     uint8_t kind;
     /* Dynamically allocated
     uint16_t type_len;
@@ -255,7 +254,7 @@ struct tt_UpdateEntity {
 } __attribute__((packed));
 
 struct tt_DataHeader {
-    uint32_t topic_id; // topic routing identity
+    uint32_t endpoint_id; // endpoint id for subscriber lookup
     uint32_t seq_no;
     uint64_t timestamp;
     // type + name

--- a/src/tickle.c
+++ b/src/tickle.c
@@ -314,7 +314,6 @@ int32_t tt_Node_create_client(struct tt_Node* node, struct tt_Client* client, st
     struct tt_Endpoint* endpoint = (struct tt_Endpoint*)client;
     endpoint->kind = tt_KIND_SERVICE_CLIENT;
     endpoint->id = tt_hash_id(service->name, endpoint_name);
-    endpoint->topic_id = 0;
     endpoint->name = endpoint_name;
     client->node = node;
     client->service = service;
@@ -337,8 +336,6 @@ int32_t tt_Node_create_server(struct tt_Node* node, struct tt_Server* server, st
     struct tt_Endpoint* endpoint = (struct tt_Endpoint*)server;
     endpoint->kind = tt_KIND_SERVICE_SERVER;
     endpoint->id = tt_hash_id(service->name, endpoint_name);
-    // Service endpoints are not topic-based, so no topic routing identifier.
-    endpoint->topic_id = 0;
     endpoint->name = endpoint_name;
     server->node = node;
     server->service = service;
@@ -361,10 +358,7 @@ int32_t tt_Node_create_publisher(struct tt_Node* node, struct tt_Publisher* pub,
                                  const char* endpoint_name) {
     struct tt_Endpoint* endpoint = (struct tt_Endpoint*)pub;
     endpoint->kind = tt_KIND_TOPIC_PUBLISHER;
-    // Unique endpoint identity used for duplicate detection and endpoint lookup.
     endpoint->id = tt_hash_id(topic->name, endpoint_name);
-    // Topic routing identity shared by all publishers/subscribers of the same topic.
-    endpoint->topic_id = tt_hash_id(topic->name, topic->name);
     endpoint->name = endpoint_name;
     pub->node = node;
     pub->topic = topic;
@@ -383,10 +377,7 @@ int32_t tt_Node_create_subscriber(struct tt_Node* node, struct tt_Subscriber* su
                                   const char* endpoint_name, tt_SUBSCRIBER_CALLBACK callback) {
     struct tt_Endpoint* endpoint = (struct tt_Endpoint*)sub;
     endpoint->kind = tt_KIND_TOPIC_SUBSCRIBER;
-    // Unique endpoint identity used for duplicate detection and endpoint lookup.
     endpoint->id = tt_hash_id(topic->name, endpoint_name);
-    // Topic routing identity shared by all publishers/subscribers of the same topic.
-    endpoint->topic_id = tt_hash_id(topic->name, topic->name);
     endpoint->name = endpoint_name;
     sub->node = node;
     sub->topic = topic;
@@ -563,9 +554,7 @@ int32_t tt_Publisher_publish(struct tt_Publisher* pub, struct tt_Data* data) {
         return -1;
     }
 
-    // The embedded endpoint metadata (`endpoint`) caches the shared topic routing id.
-    // Data fan-out is routed by topic, not by the publisher endpoint identity.
-    data_header->topic_id = pub->endpoint.topic_id;
+    data_header->endpoint_id = endpoint->id;
     data_header->seq_no = pub->seq_no + 1;
     data_header->timestamp = tt_get_ns();
 
@@ -806,7 +795,7 @@ static bool process_data(struct tt_Node* node, struct tt_Header* header, uint8_t
     }
 
     TT_LOG_DEBUG("  Data");
-    TT_LOG_DEBUG("  topic_id: %08x", data_header->topic_id);
+    TT_LOG_DEBUG("  endpoint_id: %08x", data_header->endpoint_id);
     TT_LOG_DEBUG("  timestamp: %ld", data_header->timestamp);
     TT_LOG_DEBUG("  seq_no: %d", data_header->seq_no);
 
@@ -818,9 +807,8 @@ static bool process_data(struct tt_Node* node, struct tt_Header* header, uint8_t
     tt_lock_state_t state = lock_endpoints(node);
     for (uint32_t i = 0; i < node->endpoint_count; i++) {
         struct tt_Endpoint* endpoint = node->endpoints[i];
-        // Match subscribers by the shared topic routing id carried in the data header.
         if (endpoint == NULL || endpoint->kind != tt_KIND_TOPIC_SUBSCRIBER ||
-            endpoint->topic_id != data_header->topic_id) {
+            endpoint->id != data_header->endpoint_id) {
             continue;
         }
 

--- a/src/tickle.c
+++ b/src/tickle.c
@@ -799,34 +799,20 @@ static bool process_data(struct tt_Node* node, struct tt_Header* header, uint8_t
     TT_LOG_DEBUG("  timestamp: %ld", data_header->timestamp);
     TT_LOG_DEBUG("  seq_no: %d", data_header->seq_no);
 
-    struct tt_Subscriber* subscribers[tt_MAX_ENDPOINT_COUNT];
-    uint32_t subscriber_count = 0;
-
-    // Snapshot matching subscribers while the endpoint registry is protected.
-    // Callbacks run after unlock so user code can create or remove endpoints without deadlocking.
-    tt_lock_state_t state = lock_endpoints(node);
-    for (uint32_t i = 0; i < node->endpoint_count; i++) {
-        struct tt_Endpoint* endpoint = node->endpoints[i];
-        if (endpoint == NULL || endpoint->kind != tt_KIND_TOPIC_SUBSCRIBER ||
-            endpoint->id != data_header->endpoint_id) {
-            continue;
-        }
-
-        subscribers[subscriber_count++] = (struct tt_Subscriber*)endpoint;
+    struct tt_Endpoint* endpoint = find_endpoint(node, tt_KIND_TOPIC_SUBSCRIBER, data_header->endpoint_id);
+    if (endpoint == NULL) {
+        return true;
     }
-    unlock_endpoints(node, state);
 
-    for (uint32_t i = 0; i < subscriber_count; i++) {
-        struct tt_Subscriber* sub = subscribers[i];
-        struct tt_Topic* topic = sub->topic;
+    struct tt_Subscriber* sub = (struct tt_Subscriber*)endpoint;
+    struct tt_Topic* topic = sub->topic;
 
-        uint8_t data[topic->data_size];
-        int32_t decoded =
-            topic->data_decode((struct tt_Data*)data, buffer + head, tail - head, tt_is_native_endian(header));
-        sub->callback(sub, data_header->timestamp, data_header->seq_no, (struct tt_Data*)data);
+    uint8_t data[topic->data_size];
+    int32_t decoded =
+        topic->data_decode((struct tt_Data*)data, buffer + head, tail - head, tt_is_native_endian(header));
+    sub->callback(sub, data_header->timestamp, data_header->seq_no, (struct tt_Data*)data);
 
-        topic->data_free((struct tt_Data*)data);
-    }
+    topic->data_free((struct tt_Data*)data);
 
     return true;
 }

--- a/tests/test_endpoint.c
+++ b/tests/test_endpoint.c
@@ -283,6 +283,25 @@ static void test_tt_node_create_publisher_allows_multiple_endpoints_same_topic(v
     EXPECT_TRUE(node.endpoints[1] == (struct tt_Endpoint*)&pub2);
 }
 
+static void test_tt_node_create_publisher_duplicate_name_same_topic_returns_duplicate_endpoint(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+
+    struct tt_Topic topic;
+    memset(&topic, 0, sizeof(topic));
+    topic.name = "topic";
+
+    struct tt_Publisher pub1;
+    memset(&pub1, 0, sizeof(pub1));
+    struct tt_Publisher pub2;
+    memset(&pub2, 0, sizeof(pub2));
+
+    EXPECT_TRUE(tt_Node_create_publisher(&node, &pub1, &topic, "publisher") == tt_ERROR_NONE);
+    EXPECT_TRUE(tt_Node_create_publisher(&node, &pub2, &topic, "publisher") == tt_DUPLICATE_ENDPOINT);
+    EXPECT_EQ_U32(1, node.endpoint_count);
+    EXPECT_TRUE(node.endpoints[0] == (struct tt_Endpoint*)&pub1);
+}
+
 static void test_tt_node_create_client_duplicate_returns_duplicate_endpoint(void) {
     struct tt_Node node;
     memset(&node, 0, sizeof(node));
@@ -466,12 +485,31 @@ static void test_tt_node_create_subscriber_allows_multiple_endpoints_same_topic(
     EXPECT_TRUE(node.endpoints[1] == (struct tt_Endpoint*)&sub2);
 }
 
-static void expect_two_subscribers_dispatched(void) {
-    EXPECT_TRUE(g_sub1_invocations == 1);
-    EXPECT_TRUE(g_sub2_invocations == 1);
+static void test_tt_node_create_subscriber_duplicate_name_same_topic_returns_duplicate_endpoint(void) {
+    struct tt_Node node;
+    memset(&node, 0, sizeof(node));
+
+    struct tt_Topic topic;
+    memset(&topic, 0, sizeof(topic));
+    topic.name = "topic";
+
+    struct tt_Subscriber sub1;
+    memset(&sub1, 0, sizeof(sub1));
+    struct tt_Subscriber sub2;
+    memset(&sub2, 0, sizeof(sub2));
+
+    EXPECT_TRUE(tt_Node_create_subscriber(&node, &sub1, &topic, "subscriber", NULL) == tt_ERROR_NONE);
+    EXPECT_TRUE(tt_Node_create_subscriber(&node, &sub2, &topic, "subscriber", NULL) == tt_DUPLICATE_ENDPOINT);
+    EXPECT_EQ_U32(1, node.endpoint_count);
+    EXPECT_TRUE(node.endpoints[0] == (struct tt_Endpoint*)&sub1);
 }
 
-static void test_process_data_dispatches_same_topic_to_multiple_subscribers(void) {
+static void expect_only_first_subscriber_dispatched(void) {
+    EXPECT_TRUE(g_sub1_invocations == 1);
+    EXPECT_TRUE(g_sub2_invocations == 0);
+}
+
+static void test_process_data_dispatches_matching_endpoint_to_subscriber(void) {
     struct tt_Node node;
     memset(&node, 0, sizeof(node));
 
@@ -503,7 +541,7 @@ static void test_process_data_dispatches_same_topic_to_multiple_subscribers(void
 
     uint8_t buffer[sizeof(struct tt_DataHeader) + 4];
     struct tt_DataHeader* data_header = (struct tt_DataHeader*)buffer;
-    data_header->topic_id = tt_hash_id(topic.name, topic.name);
+    data_header->endpoint_id = tt_hash_id(topic.name, "subscriber1");
     data_header->seq_no = 1;
     data_header->timestamp = k_test_data_timestamp;
     buffer[sizeof(struct tt_DataHeader) + 0] = 0x01;
@@ -518,7 +556,7 @@ static void test_process_data_dispatches_same_topic_to_multiple_subscribers(void
 
     bool process_ok = process_data(&node, &header, buffer, 0, sizeof(buffer));
     EXPECT_TRUE(process_ok);
-    expect_two_subscribers_dispatched();
+    expect_only_first_subscriber_dispatched();
     expect_endpoint_registry_lock_used(&node);
 }
 
@@ -570,9 +608,11 @@ int main(void) {
     test_tt_node_create_server_duplicate_returns_duplicate_endpoint();
     test_tt_node_create_publisher_adds_endpoint();
     test_tt_node_create_publisher_allows_multiple_endpoints_same_topic();
+    test_tt_node_create_publisher_duplicate_name_same_topic_returns_duplicate_endpoint();
     test_tt_node_create_subscriber_adds_endpoint();
     test_tt_node_create_subscriber_allows_multiple_endpoints_same_topic();
-    test_process_data_dispatches_same_topic_to_multiple_subscribers();
+    test_tt_node_create_subscriber_duplicate_name_same_topic_returns_duplicate_endpoint();
+    test_process_data_dispatches_matching_endpoint_to_subscriber();
     test_process_callrequest_finds_correct_service_server_endpoint();
     test_create_functions_return_too_many_when_endpoint_limit_reached();
 


### PR DESCRIPTION
1. Purpose
This is to revert the endpoint id that is an unique id from topic name and instance (endpoint name)

2. Overview
- Remove topic id from the Endpoint

3. Test
- tests/test_endpoint.c covers uniqueness of endpoint id from topic name and instance in publisher/subscriber creation 

5. Issue
- [SW-2019](https://linear.app/tsnlab/issue/SW-2019/tt-node-create-subscriber-%EC%97%90%EC%84%9C-endpoint-id-%EC%A4%91%EB%B3%B5-%EA%B2%80%EC%82%AC%ED%95%B4%EC%84%9C-%EC%98%A4%EB%A5%98-%EC%B2%98%EB%A6%AC)