### PR TITLE
Fix duplicate endpoint id 

### DIFF
--- a/include/tickle/config.h
+++ b/include/tickle/config.h
@@ -14,7 +14,7 @@
 #define tt_SERVER_CACHE_TIMEOUT (100 * tt_MILLISECOND) // (Client server latency) * (CALL_RETRY_COUNT + 1)
 
 #define tt_MAX_ENDPOINT_COUNT 256  // Maximum number of endpoints (data or services)
-#define tt_MAX_NAME_LENGTH 32      // Maximum length of endpoint name
+#define tt_MAX_NAME_LENGTH 64      // Maximum length of endpoint name
 #define tt_MAX_STRING_LENGTH 65535 // Maximum length of string
 #define tt_MAX_BUFFER_LENGTH 1480  // TX buffer size
 

--- a/include/tickle/config.h
+++ b/include/tickle/config.h
@@ -14,7 +14,7 @@
 #define tt_SERVER_CACHE_TIMEOUT (100 * tt_MILLISECOND) // (Client server latency) * (CALL_RETRY_COUNT + 1)
 
 #define tt_MAX_ENDPOINT_COUNT 256  // Maximum number of endpoints (data or services)
-#define tt_MAX_NAME_LENGTH 64      // Maximum length of endpoint name
+#define tt_MAX_NAME_LENGTH 255     // Maximum length of endpoint name
 #define tt_MAX_STRING_LENGTH 65535 // Maximum length of string
 #define tt_MAX_BUFFER_LENGTH 1480  // TX buffer size
 

--- a/src/encoding.c
+++ b/src/encoding.c
@@ -23,10 +23,10 @@ uint32_t tt_hash_id(const char* type, const char* name) {
     uint8_t name_len = _tt_strnlen(name, tt_MAX_NAME_LENGTH + 1);
 
     if (type_len > tt_MAX_NAME_LENGTH) {
-        TT_LOG_ERROR("Length of \"%s\" exceeds maximum string length %u.", type, tt_MAX_NAME_LENGTH);
+        TT_LOG_WARNING("Length of \"%s\" exceeds maximum string length %u.", type, tt_MAX_NAME_LENGTH);
     }
     if (name_len > tt_MAX_NAME_LENGTH) {
-        TT_LOG_ERROR("Length of \"%s\" exceeds maximum string length %u.", name, tt_MAX_NAME_LENGTH);
+        TT_LOG_WARNING("Length of \"%s\" exceeds maximum string length %u.", name, tt_MAX_NAME_LENGTH);
     }
 
     uint32_t hash = 0;

--- a/src/encoding.c
+++ b/src/encoding.c
@@ -3,6 +3,8 @@
 #include <tickle/hal.h>
 #include <tickle/tickle.h>
 
+#include "log.h"
+
 // This implementation relies on transitive includes from <tickle/hal.h> and <tickle/tickle.h>.
 // NOLINTBEGIN(misc-include-cleaner)
 
@@ -17,8 +19,15 @@ bool tt_is_reverse_endian(struct tt_Header* header) {
 
 // Hash function
 uint32_t tt_hash_id(const char* type, const char* name) {
-    uint8_t type_len = _tt_strnlen(type, tt_MAX_NAME_LENGTH);
-    uint8_t name_len = _tt_strnlen(name, tt_MAX_NAME_LENGTH);
+    uint8_t type_len = _tt_strnlen(type, tt_MAX_NAME_LENGTH + 1);
+    uint8_t name_len = _tt_strnlen(name, tt_MAX_NAME_LENGTH + 1);
+
+    if (type_len > tt_MAX_NAME_LENGTH) {
+        TT_LOG_ERROR("Length of \"%s\" exceeds maximum string length %u.", type, tt_MAX_NAME_LENGTH);
+    }
+    if (name_len > tt_MAX_NAME_LENGTH) {
+        TT_LOG_ERROR("Length of \"%s\" exceeds maximum string length %u.", name, tt_MAX_NAME_LENGTH);
+    }
 
     uint32_t hash = 0;
     ((uint8_t*)&hash)[1] = type_len;


### PR DESCRIPTION
Duplicate endpoint id error occurs when topic/service name is longer than `tt_MAX_NAME_LENGTH`

Example from ROS 2
```
/latency_publisher/get_parameter_types # length = 38
/latency_publisher/get_parameter       # length = 32
```
results of `tt_hash_id()` on both names are same.
Those topic/services are automatically registered by RCL and not modifiable, so `tt_MAX_NAME_LENGTH` must be increased.