### PR TITLE
Pre-allocate recv buffer that persists after recv timeout

### DIFF
--- a/src/tickle.c
+++ b/src/tickle.c
@@ -1285,6 +1285,7 @@ int32_t tt_Node_poll(struct tt_Node* node) {
     if (len == -1) { // Timeout
     } else if (len < 0) { // I/O error
         _tt_free(rx_buffer);
+        rx_buffer = NULL;
         perror("Cannot receive data");
         process_scheduled_tasks(node);
         return len;

--- a/src/tickle.c
+++ b/src/tickle.c
@@ -1287,7 +1287,7 @@ int32_t tt_Node_poll(struct tt_Node* node) {
     uint16_t port = 0;
     int32_t len = tt_receive(node, rx_buffer->rx_data, tt_MAX_BUFFER_LENGTH, &ip, &port);
 
-    if (len == -1) { // Timeout
+    if (len == -1) {      // Timeout
     } else if (len < 0) { // I/O error
         _tt_free(rx_buffer);
         rx_buffer = NULL;

--- a/src/tickle.c
+++ b/src/tickle.c
@@ -1265,22 +1265,24 @@ static void process_scheduled_tasks(struct tt_Node* node) {
 }
 
 int32_t tt_Node_poll(struct tt_Node* node) {
-    struct tt_RxBuffer* rx_buffer = _tt_malloc(sizeof(struct tt_RxBuffer));
-    if (rx_buffer == NULL) {
-        TT_LOG_ERROR("Out of memory");
-        return -1;
-    }
+    static struct tt_RxBuffer* rx_buffer = NULL;
 
-    rx_buffer->remaining_topic_count = 0;
-    rx_buffer->len = 0;
-    rx_buffer->next_buffer = NULL;
+    if (rx_buffer == NULL) {
+        rx_buffer = _tt_malloc(sizeof(struct tt_RxBuffer));
+        if (rx_buffer == NULL) {
+            TT_LOG_ERROR("Out of memory");
+            return -1;
+        }
+        rx_buffer->remaining_topic_count = 0;
+        rx_buffer->len = 0;
+        rx_buffer->next_buffer = NULL;
+    }
 
     uint32_t ip = 0;
     uint16_t port = 0;
     int32_t len = tt_receive(node, rx_buffer->rx_data, tt_MAX_BUFFER_LENGTH, &ip, &port);
 
     if (len == -1) { // Timeout
-        _tt_free(rx_buffer);
     } else if (len < 0) { // I/O error
         _tt_free(rx_buffer);
         perror("Cannot receive data");
@@ -1297,6 +1299,7 @@ int32_t tt_Node_poll(struct tt_Node* node) {
         if (!process_packet(node, rx_buffer)) {
             TT_LOG_ERROR("Cannot process packet");
         }
+        rx_buffer = NULL;
     }
 
     process_scheduled_tasks(node);


### PR DESCRIPTION
To prevent unnecessary memory allocation/deallocation while `tt_Node_poll` is invoked repeatedly in short period