### PR TITLE
Integrate rmw_tickle initialization part

### DIFF
--- a/.github/workflows/check-all.yml
+++ b/.github/workflows/check-all.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   check-all:
     runs-on: ubuntu-latest
+    container:
+      image: rostooling/setup-ros-docker:ubuntu-noble-latest
     permissions:
       contents: read
       pull-requests: write
@@ -23,6 +25,12 @@ jobs:
       - name: Generate compile_commands.json
         run: |
           bear -- make all
+          mv compile_commands.json src
+
+      - name: Generate compile_commands.json for rmw_tickle
+        run: |
+          colcon build --packages-select rmw_tickle --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          mv build/compile_commands.json rmw_tickle
 
       - name: Check all
         uses: tsnlab/check@main

--- a/rmw_tickle/rmw_tickle/include/rmw_tickle_c/rmw_tickle.h
+++ b/rmw_tickle/rmw_tickle/include/rmw_tickle_c/rmw_tickle.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <tickle/tickle.h>
+
+#include "rcutils/allocator.h"
+#include "rmw/rmw.h"
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_runtime_c/service_type_support_struct.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// TickLE RMW implementation identifier
+#define RMW_TICKLE_IDENTIFIER "rmw_tickle"
+
+// TickLE serialization format
+#define RMW_TICKLE_SERIALIZATION_FORMAT "tickle"
+
+// External identifier variables
+extern const char* const rmw_tickle_identifier;
+extern const char* const rmw_tickle_serialization_format;
+
+// TickLE context implementation
+typedef struct rmw_tickle_context_impl_t {
+    // Graph guard condition for node discovery
+    rmw_guard_condition_t graph_guard_condition;
+    // Placeholder for TickLE context data
+    // This can be extended with TickLE-specific context information
+    int dummy; // Temporary field to avoid empty struct
+} rmw_tickle_context_impl_t;
+
+// RMW implementation functions
+const char* rmw_get_implementation_identifier(void);
+rmw_init_options_t rmw_get_zero_initialized_init_options(void);
+
+// TickLE specific node data
+typedef struct rmw_tickle_node_t {
+    rmw_node_t rmw_node; // RMW node structure (must be first)
+    struct tt_Node tickle_node;
+    rcutils_allocator_t allocator;
+    const rmw_context_t* context; // Store context reference
+} rmw_tickle_node_t;
+
+// TickLE specific publisher data
+typedef struct rmw_tickle_publisher_t {
+    rmw_publisher_t rmw_publisher; // RMW publisher structure (must be first)
+    struct tt_Publisher tickle_publisher;
+    rmw_tickle_node_t* node;
+    const rosidl_message_type_support_t* type_support;
+} rmw_tickle_publisher_t;
+
+// TickLE specific subscriber data
+typedef struct rmw_tickle_subscriber_t {
+    rmw_subscription_t rmw_subscription; // RMW subscription structure (must be first)
+    struct tt_Subscriber tickle_subscriber;
+    rmw_tickle_node_t* node;
+    const rosidl_message_type_support_t* type_support;
+} rmw_tickle_subscriber_t;
+
+// TickLE specific client data
+typedef struct rmw_tickle_client_t {
+    rmw_client_t rmw_client; // RMW client structure (must be first)
+    struct tt_Client tickle_client;
+    rmw_tickle_node_t* node;
+    const rosidl_service_type_support_t* type_support;
+} rmw_tickle_client_t;
+
+// TickLE specific service data
+typedef struct rmw_tickle_service_t {
+    rmw_service_t rmw_service; // RMW service structure (must be first)
+    struct tt_Server tickle_server;
+    rmw_tickle_node_t* node;
+    const rosidl_service_type_support_t* type_support;
+} rmw_tickle_service_t;
+
+// TickLE specific guard condition data
+typedef struct rmw_tickle_guard_condition_t {
+    rmw_guard_condition_t rmw_guard_condition; // RMW guard condition structure (must be first)
+    bool has_triggered;
+    rcutils_allocator_t allocator;
+} rmw_tickle_guard_condition_t;
+
+// TickLE specific wait set data
+typedef struct rmw_tickle_wait_set_t {
+    rmw_wait_set_t rmw_wait_set; // RMW wait set structure (must be first)
+    rmw_tickle_guard_condition_t** guard_conditions;
+    size_t guard_condition_count;
+    rcutils_allocator_t allocator;
+} rmw_tickle_wait_set_t;
+
+#ifdef __cplusplus
+}
+#endif

--- a/rmw_tickle/rmw_tickle/include/rmw_tickle_c/rmw_tickle.h
+++ b/rmw_tickle/rmw_tickle/include/rmw_tickle_c/rmw_tickle.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stddef.h>
 #include <tickle/tickle.h>
 
 #include "rcutils/allocator.h"

--- a/rmw_tickle/rmw_tickle/src/rmw_init.c
+++ b/rmw_tickle/rmw_tickle/src/rmw_init.c
@@ -7,7 +7,7 @@
 #include "rmw/rmw.h"
 #include "rmw_tickle_c/rmw_tickle.h"
 
-rmw_ret_t rmw_init_options_init(rmw_init_options_t* init_options, rcutils_allocator_t allocator) {
+rmw_ret_t rmw_init_options_init(rmw_init_options_t* const init_options, rcutils_allocator_t allocator) {
     RCUTILS_CHECK_ARGUMENT_FOR_NULL(init_options, RMW_RET_INVALID_ARGUMENT);
     RCUTILS_CHECK_ARGUMENT_FOR_NULL(allocator.allocate, RMW_RET_INVALID_ARGUMENT);
     RCUTILS_CHECK_ARGUMENT_FOR_NULL(allocator.deallocate, RMW_RET_INVALID_ARGUMENT);
@@ -37,7 +37,7 @@ rmw_ret_t rmw_init_options_fini(rmw_init_options_t* init_options) {
     return RMW_RET_OK;
 }
 
-rmw_ret_t rmw_init_options_copy(const rmw_init_options_t* src, rmw_init_options_t* dst) {
+rmw_ret_t rmw_init_options_copy(const rmw_init_options_t* src, rmw_init_options_t* const dst) {
     RCUTILS_CHECK_ARGUMENT_FOR_NULL(src, RMW_RET_INVALID_ARGUMENT);
     RCUTILS_CHECK_ARGUMENT_FOR_NULL(dst, RMW_RET_INVALID_ARGUMENT);
 
@@ -67,7 +67,7 @@ rmw_ret_t rmw_init_options_copy(const rmw_init_options_t* src, rmw_init_options_
     return RMW_RET_OK;
 }
 
-rmw_ret_t rmw_init(const rmw_init_options_t* options, rmw_context_t* context) {
+rmw_ret_t rmw_init(const rmw_init_options_t* options, rmw_context_t* const context) {
     RCUTILS_CHECK_ARGUMENT_FOR_NULL(options, RMW_RET_INVALID_ARGUMENT);
     RCUTILS_CHECK_ARGUMENT_FOR_NULL(context, RMW_RET_INVALID_ARGUMENT);
 
@@ -113,7 +113,7 @@ rmw_ret_t rmw_shutdown(rmw_context_t* context) {
     return RMW_RET_OK;
 }
 
-rmw_ret_t rmw_context_fini(rmw_context_t* context) {
+rmw_ret_t rmw_context_fini(rmw_context_t* const context) {
     RCUTILS_CHECK_ARGUMENT_FOR_NULL(context, RMW_RET_INVALID_ARGUMENT);
 
     if (strcmp(context->implementation_identifier, RMW_TICKLE_IDENTIFIER) != 0) {

--- a/rmw_tickle/rmw_tickle/src/rmw_init.c
+++ b/rmw_tickle/rmw_tickle/src/rmw_init.c
@@ -1,0 +1,137 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "rcutils/error_handling.h"
+#include "rcutils/strdup.h"
+#include "rmw/error_handling.h"
+#include "rmw/rmw.h"
+#include "rmw_tickle_c/rmw_tickle.h"
+
+rmw_ret_t rmw_init_options_init(rmw_init_options_t* init_options, rcutils_allocator_t allocator) {
+    RCUTILS_CHECK_ARGUMENT_FOR_NULL(init_options, RMW_RET_INVALID_ARGUMENT);
+    RCUTILS_CHECK_ARGUMENT_FOR_NULL(allocator.allocate, RMW_RET_INVALID_ARGUMENT);
+    RCUTILS_CHECK_ARGUMENT_FOR_NULL(allocator.deallocate, RMW_RET_INVALID_ARGUMENT);
+
+    init_options->instance_id = 0;
+    init_options->domain_id = 0;
+    // Initialize security options to zero
+    memset(&init_options->security_options, 0, sizeof(rmw_security_options_t));
+    init_options->enclave = NULL;
+    init_options->allocator = allocator;
+    init_options->impl = NULL;
+
+    // Set the implementation identifier
+    init_options->implementation_identifier = RMW_TICKLE_IDENTIFIER;
+
+    return RMW_RET_OK;
+}
+
+rmw_ret_t rmw_init_options_fini(rmw_init_options_t* init_options) {
+    RCUTILS_CHECK_ARGUMENT_FOR_NULL(init_options, RMW_RET_INVALID_ARGUMENT);
+    rcutils_allocator_t* allocator = &init_options->allocator;
+    RCUTILS_CHECK_ALLOCATOR(allocator, return RMW_RET_INVALID_ARGUMENT);
+    if (strcmp(init_options->implementation_identifier, RMW_TICKLE_IDENTIFIER) != 0) {
+        RMW_SET_ERROR_MSG("Implementation identifiers does not match");
+        return RMW_RET_INCORRECT_RMW_IMPLEMENTATION;
+    }
+    return RMW_RET_OK;
+}
+
+rmw_ret_t rmw_init_options_copy(const rmw_init_options_t* src, rmw_init_options_t* dst) {
+    RCUTILS_CHECK_ARGUMENT_FOR_NULL(src, RMW_RET_INVALID_ARGUMENT);
+    RCUTILS_CHECK_ARGUMENT_FOR_NULL(dst, RMW_RET_INVALID_ARGUMENT);
+
+    if (strcmp(src->implementation_identifier, RMW_TICKLE_IDENTIFIER) != 0) {
+        RMW_SET_ERROR_MSG("Implementation identifiers does not match");
+        return RMW_RET_INCORRECT_RMW_IMPLEMENTATION;
+    }
+
+    if (NULL != dst->implementation_identifier) {
+        RMW_SET_ERROR_MSG("expected zero-initialized dst");
+        return RMW_RET_INVALID_ARGUMENT;
+    }
+
+    // Copy the basic structure
+    memcpy(dst, src, sizeof(rmw_init_options_t));
+
+    // Copy the enclave string if it exists
+    if (src->enclave != NULL) {
+        dst->enclave = rcutils_strdup(src->enclave, src->allocator);
+        if (NULL == dst->enclave) {
+            return RMW_RET_BAD_ALLOC;
+        }
+    } else {
+        dst->enclave = NULL;
+    }
+
+    return RMW_RET_OK;
+}
+
+rmw_ret_t rmw_init(const rmw_init_options_t* options, rmw_context_t* context) {
+    RCUTILS_CHECK_ARGUMENT_FOR_NULL(options, RMW_RET_INVALID_ARGUMENT);
+    RCUTILS_CHECK_ARGUMENT_FOR_NULL(context, RMW_RET_INVALID_ARGUMENT);
+
+    if (strcmp(options->implementation_identifier, RMW_TICKLE_IDENTIFIER) != 0) {
+        RMW_SET_ERROR_MSG("Expected implementation identifier to be " RMW_TICKLE_IDENTIFIER);
+        return RMW_RET_INCORRECT_RMW_IMPLEMENTATION;
+    }
+
+    context->instance_id = 0;
+    context->implementation_identifier = RMW_TICKLE_IDENTIFIER;
+    context->options = *options;
+
+    // Allocate and initialize context implementation
+    rmw_tickle_context_impl_t* impl = (rmw_tickle_context_impl_t*)options->allocator.allocate(
+        sizeof(rmw_tickle_context_impl_t), options->allocator.state);
+    if (impl == NULL) {
+        RMW_SET_ERROR_MSG("Failed to allocate context implementation");
+        return RMW_RET_BAD_ALLOC;
+    }
+
+    // Initialize the context implementation
+    memset(impl, 0, sizeof(rmw_tickle_context_impl_t));
+
+    // Initialize graph guard condition
+    impl->graph_guard_condition.implementation_identifier = RMW_TICKLE_IDENTIFIER;
+    impl->graph_guard_condition.data = NULL;
+
+    context->impl = (rmw_context_impl_t*)impl;
+
+    _tt_CONFIG.broadcast = "192.168.10.255";
+
+    return RMW_RET_OK;
+}
+
+rmw_ret_t rmw_shutdown(rmw_context_t* context) {
+    RCUTILS_CHECK_ARGUMENT_FOR_NULL(context, RMW_RET_INVALID_ARGUMENT);
+
+    if (strcmp(context->implementation_identifier, RMW_TICKLE_IDENTIFIER) != 0) {
+        RMW_SET_ERROR_MSG("Expected implementation identifier to be " RMW_TICKLE_IDENTIFIER);
+        return RMW_RET_INCORRECT_RMW_IMPLEMENTATION;
+    }
+
+    return RMW_RET_OK;
+}
+
+rmw_ret_t rmw_context_fini(rmw_context_t* context) {
+    RCUTILS_CHECK_ARGUMENT_FOR_NULL(context, RMW_RET_INVALID_ARGUMENT);
+
+    if (strcmp(context->implementation_identifier, RMW_TICKLE_IDENTIFIER) != 0) {
+        RMW_SET_ERROR_MSG("Expected implementation identifier to be " RMW_TICKLE_IDENTIFIER);
+        return RMW_RET_INCORRECT_RMW_IMPLEMENTATION;
+    }
+
+    // Free the context implementation
+    if (context->impl != NULL) {
+        context->options.allocator.deallocate(context->impl, context->options.allocator.state);
+        context->impl = NULL;
+    }
+
+    // Finalize the init options
+    rmw_ret_t ret = rmw_init_options_fini(&context->options);
+    if (ret != RMW_RET_OK) {
+        return ret;
+    }
+
+    return RMW_RET_OK;
+}


### PR DESCRIPTION
This PR includes 2 files

* `rmw_tickle.h`

Provides `struct` definitions of RMW Context, Node, Publisher, Subscriber, and etc.  

* `rmw_init.c`

RMW initialization and shutdown

All files are copied from rmw_tickle demo branch: https://github.com/tsnlab/rmw_tickle/tree/demo/rmw_tickle