### PR TITLE
Fix SetBool message-length truncation bug and tighten build hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,12 @@
 *.app
 *.i*86
 *.x86_64
+
+# Project build outputs (see Makefile: set_bool/uint64 example binaries)
+/client
+/server
+/publisher
+/subscriber
 *.hex
 
 # Debug files

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 INCLUDE=include
 CC=gcc
 AR=ar
-CFLAGS=-I$(INCLUDE) -Isrc -O0 -g
+CFLAGS=-I$(INCLUDE) -Isrc -O0 -g -Wall -Wextra
 LDFLAGS=
 
 SRC=src
@@ -57,8 +57,8 @@ subscriber: examples/uint64/UInt64.c examples/uint64/subscriber.c libtickle.a
 	$(CC) -o $@ examples/uint64/UInt64.c examples/uint64/subscriber.c -L. -ltickle $(CFLAGS) $(LDFLAGS)
 
 lint:
-	find . -name '*.[ch]' -exec clang-format --dry-run --Werror {} \;
-	find . -name '*.[ch]' -exec clang-tidy {} -- -I$(INCLUDE) -I$(SRC) \;
+	find . -name '*.[ch]' -exec clang-format --dry-run --Werror {} +
+	find . -name '*.[ch]' -exec clang-tidy --extra-arg=-I$(INCLUDE) --extra-arg=-I$(SRC) {} +
 
 createns:
 # Ref: https://medium.com/@tech_18484/how-to-create-network-namespace-in-linux-host-83ad56c4f46f

--- a/examples/set_bool/SetBool.c
+++ b/examples/set_bool/SetBool.c
@@ -70,6 +70,10 @@ void SetBoolRequest_free(struct SetBoolRequest* request) {
 }
 
 int32_t SetBoolResponse_encode_size(struct SetBoolResponse* response) {
+    if (response->message == NULL) {
+        return -3; // Invalid message pointer
+    }
+
     return (int32_t)(sizeof(bool) +                                             // encode success
                      sizeof(uint16_t) +                                         // encode message length
                      _tt_strnlen(response->message, tt_MAX_STRING_LENGTH) + 1); // encode message
@@ -93,12 +97,19 @@ int32_t SetBoolResponse_encode(struct SetBoolResponse* response, uint8_t* payloa
         return -1;
     }
 
-    uint16_t message_length = _tt_strnlen(response->message, tt_MAX_STRING_LENGTH) + 1; // including '\0'
+    // Check if message is valid before measuring/copying it
+    if (response->message == NULL) {
+        return -3; // Invalid message pointer
+    }
+
+    // Measure in a wide type first: message_length (incl. '\0') can reach tt_MAX_STRING_LENGTH + 1,
+    // which overflows uint16_t, so this must be validated before narrowing.
+    size_t message_length = _tt_strnlen(response->message, tt_MAX_STRING_LENGTH) + 1; // including '\0'
     if (message_length > tt_MAX_STRING_LENGTH) {
         return -2;
     }
 
-    *(uint16_t*)payload = message_length;
+    *(uint16_t*)payload = (uint16_t)message_length;
 
     encoded += sizeof(uint16_t);
     payload += sizeof(uint16_t);
@@ -108,14 +119,9 @@ int32_t SetBoolResponse_encode(struct SetBoolResponse* response, uint8_t* payloa
         return -1;
     }
 
-    // Check if message is valid before copying
-    if (response->message == NULL) {
-        return -3; // Invalid message pointer
-    }
-
     memcpy(payload, response->message, message_length);
     payload += message_length;
-    encoded += message_length;
+    encoded += (int32_t)message_length;
 
     return encoded;
 }
@@ -166,5 +172,6 @@ int32_t SetBoolResponse_decode(struct SetBoolResponse* response, const uint8_t* 
 }
 
 void SetBoolResponse_free(struct SetBoolResponse* response) {
+    (void)response;
     // Do nothing
 }


### PR DESCRIPTION
SetBoolResponse_encode validated message_length (uint16_t) against tt_MAX_STRING_LENGTH (65535, == UINT16_MAX) only after narrowing to uint16_t, so the check could never fire. Worse, a message longer than 65535 chars silently overflowed the uint16_t length to 0, causing an empty message to be sent instead of an error. Measure the length in a wide type before narrowing, and validate before truncating. Also move the response->message NULL check before the strnlen() call that dereferences it (previously checked too late in encode, and not checked at all in encode_size), and add the missing (void)response cast in SetBoolResponse_free for consistency with its siblings.

Also:
- gitignore the extension-less example binaries (client/server/ publisher/subscriber) that were showing up as untracked
- make `find -exec ... {} \;` in the lint target use `{} +` instead, so a lint violation actually fails the `make lint` exit code
- enable -Wall -Wextra in CFLAGS so real compiler diagnostics are no longer invisible during a normal build